### PR TITLE
Typo in [include] section example

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -990,7 +990,7 @@ configuration.
 .. code-block:: ini
 
    [include]
-   file = /an/absolute/filename.conf /an/absolute/*.conf foo.conf config??.conf
+   files = /an/absolute/filename.conf /an/absolute/*.conf foo.conf config??.conf
 
 ``[group:x]`` Section Settings
 ------------------------------


### PR DESCRIPTION
I fixed a typo in [include] section example. Please pull and regenerate the docs.
