### PR TITLE
Don't bail out if we want a ulimit above our hard limit.

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -1212,7 +1212,7 @@ class ServerOptions(Options):
             
             if (soft < min) and (soft != -1): # -1 means unlimited 
                 if (hard < min) and (hard != -1):
-                    self.usage(msg % locals())
+                    hard = min
 
                 try:
                     resource.setrlimit(res, (min, hard))


### PR DESCRIPTION
Most people run supervisord as root.  When root, supervisord can
legitimately increase its ulimit above the hard limit.  When not
root, setrlimit will throw an error, which is already handled
appropriately.

Without this, one needs to further edit startup scripts to raise
the limits before supervisord starts, which increases deployment
complexity.  People are also often confused with PAM's limits.conf
and will edit that instead, to find out that their change works
until the machine reboots and supervisord is started with lowered
ulimit during the boot process (where PAM doesn't intervene).
