### PR TITLE
change webui action response to use referring url instead of server url for location header

### DIFF
--- a/supervisor/http.py
+++ b/supervisor/http.py
@@ -307,6 +307,15 @@ class deferring_http_request(http_server.http_request):
                     env[key]=value
         return env
 
+    def get_referring_url(self):
+        environ = self.cgi_environment()
+        if environ.has_key('HTTP_REFERER'):
+            url = environ['HTTP_REFERER'].strip()
+            url = url.split('?')[0]
+            return url
+        else:
+            return ''
+    
     def get_server_url(self):
         """ Functionality that medusa's http request doesn't have; set an
         attribute named 'server_url' on the request based on the Host: header

--- a/supervisor/web.py
+++ b/supervisor/web.py
@@ -387,7 +387,7 @@ class StatusView(MeldView):
                 if message is NOT_DONE_YET:
                     return NOT_DONE_YET
                 if message is not None:
-                    server_url = form['SERVER_URL']
+                    server_url = form['REFERER_URL']
                     location = server_url + '?message=%s' % urllib.quote(
                         message)
                     response['headers']['Location'] = location
@@ -547,6 +547,7 @@ class supervisor_ui_handler:
             form[k] = v
 
         form['SERVER_URL'] = request.get_server_url()
+        form['REFERER_URL'] = request.get_referring_url()
 
         path = form['PATH_INFO']
         # strip off all leading slashes


### PR DESCRIPTION
If the supervisor web ui is deployed at a subdirectory (instead of a virtual host), the user is redirected to the wrong url when an action response is received.  The location header requires an absolute url, and the HTTP_HOST was being used to construct this url.  Using referring url instead (after dropping the query part of the url) ensures that the user is redirected to the appropriate page.
