### PR TITLE
Giving up puts us in the FATAL state, not ERROR.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -664,8 +664,8 @@ where specified.
 
   The number of serial failure attempts that :program:`supervisord`
   will allow when attempting to start the program before giving up and
-  puting the process into an ``ERROR`` state.  See
-  :ref:`process_states` for explanation of the ``ERROR`` state.
+  puting the process into an ``FATAL`` state.  See
+  :ref:`process_states` for explanation of the ``FATAL`` state.
 
   *Default*: 3
 


### PR DESCRIPTION
I found this while browsing the documentation to tweak the number of retries our process has.  I did follow the code path, and give_up() is called which does place the process into the FATAL state.
