### PR TITLE
Server Error behind Nginx using Unix Domain Sockets

### DIFF
--- a/supervisor/http.py
+++ b/supervisor/http.py
@@ -293,7 +293,10 @@ class deferring_http_request(http_server.http_request):
         if query:
             env['QUERY_STRING'] = query
         env['GATEWAY_INTERFACE'] = 'CGI/1.1'
-        env['REMOTE_ADDR'] = self.channel.addr[0]
+        if self.channel.addr:
+            env['REMOTE_ADDR'] = self.channel.addr[0]
+        else:
+            env['REMOTE_ADDR'] = '127.0.0.1'
 
         for header in self.header:
             key,value=header.split(":",1)


### PR DESCRIPTION
Hello,

I tried putting Nginx as a proxy in front of Supervisor using a Unix Domain Socket. I was getting a 500 Server Error, and turning on TRACE logging showed this:

Server Error: <type 'exceptions.IndexError'>, string index out of range: file: /usr/lib/python2.6/site-packages/supervisor/http.py line: 310

The fix is pretty self-explanatory and now it works great.
- david
