### PR TITLE
Fails to run properly when installed with 'python setup.py install'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ dist = setup(
     zip_safe = False,
     namespace_packages = ['supervisor'],
     test_suite = "supervisor.tests",
+    data_files = [ ('supervisor', [version_txt]) ],
     entry_points = {
      'supervisor_rpc':['main = supervisor.rpcinterface:make_main_rpcinterface'],
      'console_scripts': [


### PR DESCRIPTION
Hello,

After cloning supervisor's git repository and installing it with:

sudo python setup.py install

supervisorctl fails with the following traceback: 

Traceback (most recent call last):
  File "/usr/local/bin/supervisorctl", line 9, in <module>
    load_entry_point('supervisor==3.0a10', 'console_scripts', 'supervisorctl')()

[...]

  File "/usr/local/lib/python2.7/dist-packages/supervisor-3.0a10-py2.7.egg/supervisor/options.py", line 55, in <module>
    VERSION = open(version_txt).read().strip()
IOError: [Errno 2] No such file or directory: '/usr/local/lib/python2.7/dist-packages/supervisor-3.0a10-py2.7.egg/supervisor/version.txt'

Adding version.txt to the list of included data_files fixes the problem.
