### PR TITLE
Fall back to cProfile if profile doesn't exist.

### DIFF
--- a/supervisor/supervisord.py
+++ b/supervisor/supervisord.py
@@ -322,7 +322,15 @@ def timeslice(period, when):
 
 # profile entry point
 def profile(cmd, globals, locals, sort_order, callers):
-    import profile
+    try:
+        import profile
+    except ImportError, e:
+        # 'profile' is not included in standard Python distribution on Debian
+        # due to licensing issues[1]. We try to use *cProfile* (which mimics
+        # profile's behaviour) instead.
+        #
+        # [1] http://stackoverflow.com/questions/8369678/is-the-profile-package-part-of-python-standard-distribution
+        import cProfile as profile
     import pstats
     import tempfile
     fd, fn = tempfile.mkstemp()


### PR DESCRIPTION
Due to licensing issues[1], the 'profile' package is not shipped with the
Debian standard Python distribution. Unfortunately, the profile
package does not have an equivalent PyPi package and can thus not be
added as a dependency to setup.py. To resolve this issue today, a
developer needs to manually install the Debian package 'python-profiler'.

[1] http://bugs.python.org/issue12417

This was reported in issue #63 and this commit resolves the issue by
allowing a fallback to the 'cProfile' package if 'profile' can't be
imported. The 'cProfile' package does not have licensing issues and is
included in the Debian Python distribution by default (since
Python 2.5).

See also [2] for further information.

[2] http://stackoverflow.com/questions/8369678/is-the-profile-package-part-of-python-standard-distribution
