### PR TITLE
ReStructuredText markup fixes

### DIFF
--- a/PLUGINS.rst
+++ b/PLUGINS.rst
@@ -22,8 +22,7 @@ listeners.
 `mr.rubber <https://github.com/collective/mr.rubber>`_
     An event listener that makes it possible to scale the number of
     processes to the number of cores on the supervisor host.
-`supervisor-wildcards
-<https://github.com/aleszoulek/supervisor-wildcards>`_
+`supervisor-wildcards <https://github.com/aleszoulek/supervisor-wildcards>`_
     Implemenents start/stop/restart commands with wildcard support for
     Supervisor.
 `mr.laforge <https://github.com/fschulze/mr.laforge>`_
@@ -49,24 +48,19 @@ with 3rd party applications:
 
 `django-supervisor <http://pypi.python.org/pypi/django-supervisor/>`_
     Easy integration between djangocl and supervisord.
-`collective.recipe.supervisor
-<http://pypi.python.org/pypi/collective.recipe.supervisor>`
+`collective.recipe.supervisor <http://pypi.python.org/pypi/collective.recipe.supervisor>`_
     A buildout recipe to install supervisor.
-`puppet-module-supervisor
-<https://github.com/plathrop/puppet-module-supervisor>`_
+`puppet-module-supervisor <https://github.com/plathrop/puppet-module-supervisor>`_
     Puppet module for configuring the supervisor daemon tool.
 `ngx_supervisord <https://github.com/FRiCKLE/ngx_supervisord>`_
     An nginx module providing API to communicate with supervisord and
     manage (start/stop) backends on-demand.
-`Supervisord-Nagios-Plugin
-<https://github.com/Level-Up/Supervisord-Nagios-Plugin>`_
+`Supervisord-Nagios-Plugin <https://github.com/Level-Up/Supervisord-Nagios-Plugin>`_
     A Nagios/icinga plugin to monitor individual supervisord processes.
-`php-supervisor-event
-<https://github.com/mtdowling/php-supervisor-event>`_
+`php-supervisor-event <https://github.com/mtdowling/php-supervisor-event>`_
     PHP classes for interacting with Supervisor event notifications.
 `sd-supervisord <https://github.com/robcowie/sd-supervisord>`_
-    `Server Density <http://www.serverdensity.com>` plugin for
+    `Server Density <http://www.serverdensity.com>`_ plugin for
     supervisor.
-`node-supervisord-eventlistener
-<https://github.com/sugendran/node-supervisord-eventlistener>`_
+`node-supervisord-eventlistener <https://github.com/sugendran/node-supervisord-eventlistener>`_
     Lists for supervisord events and raises them.


### PR DESCRIPTION
- Adding a couple missing underscores.
- Seems Github/ReStructuredText are not too fond when there's a newline
  within a link.
