### PR TITLE
Fix log rotation for shared files

### DIFF
--- a/supervisor/tests/test_loggers.py
+++ b/supervisor/tests/test_loggers.py
@@ -162,13 +162,13 @@ class RotatingFileHandlerTests(FileHandlerTests):
         handler2.emit(new_record)
         self.assertTrue(open(self.filename).read().endswith(""))
 
-##     def test_reopen_raises(self):
-##         handler = self._makeOne(self.filename)
-##         stream = DummyStream()
-##         handler.baseFilename = os.path.join(self.basedir, 'notthere', 'a.log')
-##         handler.open_streams[handler.baseFilename] = stream
-##         self.assertRaises(IOError, handler.reopen)
-##         self.assertEqual(stream.closed, True)
+    def test_reopen_raises(self):
+        handler = self._makeOne(self.filename)
+        stream = DummyStream()
+        handler.baseFilename = os.path.join(self.basedir, 'notthere', 'a.log')
+        handler.open_streams[handler.baseFilename] = stream
+        self.assertRaises(IOError, handler.reopen)
+        self.assertEqual(stream.closed, True)
 
     def test_emit_does_rollover(self):
         handler = self._makeOne(self.filename, maxBytes=10, backupCount=2)


### PR DESCRIPTION
Better pull request ala #10 for issue 10.

First commit is a failing test, second is an implemenation and an additional test.

Fixes issue where when multiple processes refer to the same log file and the file reaches the byte limit, the log rolls over in an unpredictable fashion as all logging handlers refer to the original file (and therefore attempt to roll it with their next attempt to log).

This implementation uses a descriptor to interact with a class variable, a global dictionary using the original filepath as a key whose values are the currently open streams (aka the current actual file logged).  On rollover, the current stream for a particular "file" is updated.  This avoids the issue of old handlers referring to the inode of the renamed file by always grabbing the current file. 
