### PR TITLE
Use a set, lose dedupe function, since we no longer need to support Py23

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -622,7 +622,7 @@ class ServerOptions(Options):
                     result_handler, section))
             pool_event_names = [x.upper() for x in
                                 list_of_strings(get(section, 'events', ''))]
-            pool_event_names = dedupe(pool_event_names)
+            pool_event_names = set(pool_event_names)
             if not pool_event_names:
                 raise ValueError('[%s] section requires an "events" line' %
                                  section)
@@ -1919,12 +1919,6 @@ def split_namespec(namespec):
         # group name is same as process name
         group_name, process_name = namespec, namespec
     return group_name, process_name
-
-def dedupe(L):
-    D = {}
-    for thing in L:
-        D[thing] = 1
-    return D.keys()
 
 # exceptions
 


### PR DESCRIPTION
Note: Once we stop supporting Py26, we can just make L623 a set comprehension.
