### PR TITLE
deferring_http_channel.delay is not reset appropriately

### DIFF
--- a/supervisor/http.py
+++ b/supervisor/http.py
@@ -387,6 +387,7 @@ class deferring_http_channel(http_server.http_channel):
 
                 elif data:
                     self.ac_out_buffer = self.ac_out_buffer + data
+                    self.delay = False
                     return
                 else:
                     self.producer_fifo.pop()


### PR DESCRIPTION
https://github.com/Supervisor/supervisor/issues/112

In deferring_http_channel.refill_buffer(), if the underlying callback returns
NOT_DONE_YET, the channel's "delay" field is set to match the callback's delay.
But later, when the callback is done, the delay is not reset.

The issue this was causing for me is that, later on, when a different callback
that returned a lot of data was being executed, unnecessary delays were being
added: 4k of data would be sent, then the code would go back to the main loop,
where, because of the delay, the channel would not be added to the writer fd
set; so it would instead delay the writing of the next 4k of data another whole
second, since that's the timeout hardcoded in the main loop.

Since the reply supervisor was trying to send spanned several 4k packets, it
was taking several seconds to send a reply that was already computed in memory.
