### PR TITLE
Add note in help about restart and config changes

### DIFF
--- a/supervisor/supervisorctl.py
+++ b/supervisor/supervisorctl.py
@@ -764,6 +764,8 @@ class DefaultControllerPlugin(ControllerPluginBase):
         self.ctl.output("restart <name> <name>\tRestart multiple processes or "
                      "groups")
         self.ctl.output("restart all\t\tRestart all processes")
+        self.ctl.output("Note: restart does not reread config files. For that,"
+                        " see reread and update.")
 
     def do_shutdown(self, arg):
         if self.ctl.options.interactive:


### PR DESCRIPTION
I wasted plenty of time troubleshooting my code when what was really happening was that my config changes were not applied. One expects "restart" to start afresh with current config files (at least when one is new to supervisord). So this adds a message about it in "help restart" output.
