### PR TITLE
Simplify dict_of_key_value_pairs

### DIFF
--- a/supervisor/datatypes.py
+++ b/supervisor/datatypes.py
@@ -78,7 +78,7 @@ def dict_of_key_value_pairs(arg):
 
     D = {}
     i = 0
-    while i in range(0, tokens_len):
+    while i < tokens_len:
         k_eq_v = tokens[i:i+3]
         if len(k_eq_v) != 3:
             raise ValueError, "Unexpected end of key/value pairs"


### PR DESCRIPTION
There is no need to create a range every loop if all you are testing is if `i` is within bounds. :-)
