### PR TITLE
Verify that key/value pairs are correctly separated.

### DIFF
--- a/supervisor/datatypes.py
+++ b/supervisor/datatypes.py
@@ -80,7 +80,7 @@ def dict_of_key_value_pairs(arg):
     i = 0
     while i in range(0, tokens_len):
         k_eq_v = tokens[i:i+3]
-        if len(k_eq_v) != 3:
+        if len(k_eq_v) != 3 or k_eq_v[1] != '=':
             raise ValueError, "Unexpected end of key/value pairs"
         D[k_eq_v[0]] = k_eq_v[2].strip('\'"')
         i += 4


### PR DESCRIPTION
Test that there is, in fact, an '=' equals sign separating the key and value. If not, there is probably a syntax error in the value somewhere, such as a missing comma. Without this change, the lexer happily uses the next key as a separator, and provided there are enough tokens left you get unexpected results:

```
 >>> dict_of_key_value_pairs('KEY1=look-ma-no-comma KEY2=ends-with-comma,')
 {'KEY1': 'look-ma-no-comma', '=': ','}
```

Testing for the equals sign catches the above error.
