### PR TITLE
Fixing `tests_require` in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ dist = setup(
     packages = find_packages(),
     install_requires = requires,
     extras_require = {'iterparse':['cElementTree >= 1.0.2']},
-    tests_require = requires + ['mock >= 0.5.0'],
+    tests_require = ['mock >= 0.5.0'],
     include_package_data = True,
     zip_safe = False,
     namespace_packages = ['supervisor'],


### PR DESCRIPTION
The attribute need only to specify _additional_ dependencies for running
tests. Please see http://packages.python.org/distribute/setuptools.html
for details.
