### PR TITLE
Allow separate working directories for different instances of same program

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -774,7 +774,6 @@ class ServerOptions(Options):
         stdout_events = boolean(get(section, 'stdout_events_enabled','false'))
         stderr_cmaxbytes = byte_size(get(section,'stderr_capture_maxbytes','0'))
         stderr_events = boolean(get(section, 'stderr_events_enabled','false'))
-        directory = get(section, 'directory', None)
         serverurl = get(section, 'serverurl', None)
         if serverurl and serverurl.strip().upper() == 'AUTO':
             serverurl = None
@@ -811,6 +810,7 @@ class ServerOptions(Options):
             environment = dict_of_key_value_pairs(
                 expand(environment_str, expansions, 'environment'))
 
+            directory = get(section, 'directory', None)
             if directory:
                 directory = expand(directory, expansions, 'directory')
 

--- a/supervisor/tests/test_options.py
+++ b/supervisor/tests/test_options.py
@@ -227,6 +227,14 @@ class ServerOptionsTests(unittest.TestCase):
         numprocs = 2
         command = /bin/cat
         autorestart=unexpected
+
+        [program:cat5]
+        priority=5
+        process_name = foo_%%(process_num)02d
+        numprocs = 2
+        numprocs_start = 1
+        command = /bin/cat
+        directory = /some/path/foo_%%(process_num)02d
         """ % {'tempdir':tempfile.gettempdir()})
 
         from supervisor import datatypes
@@ -257,7 +265,7 @@ class ServerOptionsTests(unittest.TestCase):
         self.assertEqual(options.minfds, 2048)
         self.assertEqual(options.minprocs, 300)
         self.assertEqual(options.nocleanup, True)
-        self.assertEqual(len(options.process_group_configs), 4)
+        self.assertEqual(len(options.process_group_configs), 5)
         self.assertEqual(options.environment, dict(FAKE_ENV_VAR='/some/path'))
 
         cat1 = options.process_group_configs[0]
@@ -350,6 +358,7 @@ class ServerOptionsTests(unittest.TestCase):
         self.assertEqual(proc4_a.stopsignal, signal.SIGTERM)
         self.assertEqual(proc4_a.stopasgroup, False)
         self.assertEqual(proc4_a.killasgroup, False)
+        self.assertEqual(proc4_a.directory, None)
 
         proc4_b = cat4.process_configs[1]
         self.assertEqual(proc4_b.name, 'fleeb_1')
@@ -367,6 +376,20 @@ class ServerOptionsTests(unittest.TestCase):
         self.assertEqual(proc4_b.stopsignal, signal.SIGTERM)
         self.assertEqual(proc4_b.stopasgroup, False)
         self.assertEqual(proc4_b.killasgroup, False)
+        self.assertEqual(proc4_b.directory, None)
+
+        cat5 = options.process_group_configs[4]
+        self.assertEqual(cat5.name, 'cat5')
+        self.assertEqual(cat5.priority, 5)
+        self.assertEqual(len(cat5.process_configs), 2)
+
+        proc5_a = cat5.process_configs[0]
+        self.assertEqual(proc5_a.name, 'foo_01')
+        self.assertEqual(proc5_a.directory, '/some/path/foo_01')
+
+        proc5_b = cat5.process_configs[1]
+        self.assertEqual(proc5_b.name, 'foo_02')
+        self.assertEqual(proc5_b.directory, '/some/path/foo_02')
 
         here = os.path.abspath(os.getcwd())
         self.assertEqual(instance.uid, 0)


### PR DESCRIPTION
Currently it is not possible to specify separate working directories for each instance of the [program:x]. In other words following config does not work as one would expect:

```
    [program:foo]
    process_name = foo_%(process_num)02d
    numprocs = 2
    numprocs_start = 1
    command = foo
    directory = /some/path/foo_%%(process_num)02d
```

Instead of having different working directories the processes will share the same directory, which is actually chosen randomly (either foo_01 or foo_02) in this case. 

This patch fixes the problem by moving expansion of the directory variable to the correct place, inside the same loop where other instance related variables are expanded.
