### PR TITLE
Let the supervisord daemon log to syslog.

### DIFF
--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -14,7 +14,11 @@ messages about its own health, its subprocess' state changes, any
 messages that result from events, and debug and informational
 messages.  The path to the activity log is configured via the
 ``logfile`` parameter in the ``[supervisord]`` section of the
-configuration file, defaulting to :file:`$CWD/supervisord.log`.
+configuration file, defaulting to :file:`$CWD/supervisord.log`.  If
+the value of this option is the special string "syslog", the logs of
+the :program"`supervisord` will be routed to the syslog service
+instead of being written to a files.  As a consequence, the options
+``logfile_maxbytes`` and ``logfile_backups`` will be ignored.
 Sample activity log traffic is shown in the example below.  Some lines
 have been broken to better fit the screen.
 

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -447,7 +447,11 @@ class ServerOptions(Options):
         else:
             logfile = section.logfile
 
-        self.logfile = normalize_path(logfile)
+        if logfile != 'syslog':
+            # if the value for logfile is "syslog", we don't want to
+            # normalize the path to something like $CWD/syslog.log, but
+            # instead use the syslog service.
+            self.logfile = normalize_path(logfile)
 
         if self.pidfile:
             pidfile = self.pidfile


### PR DESCRIPTION
When the options `stdout_logfile` or `stderr_logfile` are set to
"syslog", the children are logging to the syslog service,
but the daemon is still logging to a file.

By letting the possibility to set the value for `logfile` to
"syslog", we can have the same behavior for the daemon.
