### PR TITLE
Handle ValueError raised when parsing command in get_execv_args

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -1957,6 +1957,9 @@ def split_namespec(namespec):
 class ProcessException(Exception):
     """ Specialized exceptions used when attempting to start a process """
 
+class BadCommand(ProcessException):
+    """ Indicates the command could not be parsed properly. """
+
 class NotExecutable(ProcessException):
     """ Indicates that the filespec cannot be executed because its path
     resolves to a file which is not executable, or which is a directory. """

--- a/supervisor/process.py
+++ b/supervisor/process.py
@@ -16,7 +16,7 @@ from supervisor.states import STOPPED_STATES
 
 from supervisor.options import decode_wait_status
 from supervisor.options import signame
-from supervisor.options import ProcessException
+from supervisor.options import ProcessException, BadCommand
 
 from supervisor.dispatchers import EventListenerStates
 
@@ -100,7 +100,11 @@ class Subprocess:
         """Internal: turn a program name into a file name, using $PATH,
         make sure it exists / is executable, raising a ProcessException
         if not """
-        commandargs = shlex.split(self.config.command)
+        try:
+            commandargs = shlex.split(self.config.command)
+        except ValueError, e:
+            raise BadCommand("can't parse command %r: %s" % \
+                (self.config.command, str(e)))
 
         program = commandargs[0]
 

--- a/supervisor/tests/test_process.py
+++ b/supervisor/tests/test_process.py
@@ -19,6 +19,7 @@ from supervisor.tests.base import DummyFCGIProcessGroup
 from supervisor.tests.base import DummySocketManager
 
 from supervisor.process import Subprocess
+from supervisor.options import BadCommand
 
 class SubprocessTests(unittest.TestCase):
     def _getTargetClass(self):
@@ -97,6 +98,12 @@ class SubprocessTests(unittest.TestCase):
         instance.drain()
         self.assertTrue(instance.dispatchers[0].read_event_handled)
         self.assertTrue(instance.dispatchers[1].write_event_handled)
+
+    def test_get_execv_args_bad_command(self):
+        options = DummyOptions()
+        config = DummyPConfig(options, 'extraquote', 'extraquote"')
+        instance = self._makeOne(config)
+        self.assertRaises(BadCommand, instance.get_execv_args)
         
     def test_get_execv_args_abs_missing(self):
         options = DummyOptions()


### PR DESCRIPTION
Fix for issue #175
