### PR TITLE
Adding `supervisor/version.txt` to distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include supervisor/version.txt


### PR DESCRIPTION
Without this, using `supervisord` and/or `supervisorctl`, when installed from source,
does not work.

To reproduce this, do:
1. `cd src`
2. `virtualenv --no-site-packages supervisor_virtenv`
3. `source supervisor_virtenv/bin/activate`
4. `cd ~/src/supervisor`
5. `python ./setup.py install`
6. `cd ~/src/supervisor_virtualenv`
7. Execute `./bin/supervisorctl` or `./bin/supervisord`

The output I get is:

``` bash
$ ./bin/supervisord
Traceback (most recent call last):
  File "./bin/supervisord", line 9, in <module>
    load_entry_point('supervisor==3.0b2-dev', 'console_scripts', 'supervisord')()
  File "/Users/jens/Development/src/external_projects/supervisor_virtenv/lib/python2.7/site-packages/distribute-0.6.28-py2.7.egg/pkg_resources.py", line 337, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/Users/jens/Development/src/external_projects/supervisor_virtenv/lib/python2.7/site-packages/distribute-0.6.28-py2.7.egg/pkg_resources.py", line 2311, in load_entry_point
    return ep.load()
  File "/Users/jens/Development/src/external_projects/supervisor_virtenv/lib/python2.7/site-packages/distribute-0.6.28-py2.7.egg/pkg_resources.py", line 2017, in load
    entry = __import__(self.module_name, globals(),globals(), ['__name__'])
  File "/Users/jens/Development/src/external_projects/supervisor_virtenv/lib/python2.7/site-packages/supervisor-3.0b2_dev-py2.7.egg/supervisor/supervisord.py", line 41, in <module>
    from supervisor.options import ServerOptions
  File "/Users/jens/Development/src/external_projects/supervisor_virtenv/lib/python2.7/site-packages/supervisor-3.0b2_dev-py2.7.egg/supervisor/options.py", line 56, in <module>
    VERSION = open(version_txt).read().strip()
IOError: [Errno 2] No such file or directory: '/Users/jens/Development/src/external_projects/supervisor_virtenv/lib/python2.7/site-packages/supervisor-3.0b2_dev-py2.7.egg/supervisor/version.txt'
```

Same exception is raised for

``` bash
$ ./bin/supervisorctl
```

This is because `version.txt` is not bundled with the package. This (very tiny) pull request fixes this.
