### PR TITLE
Fixed output of logs (tail/maintail) in the Web UI

### DIFF
--- a/supervisor/http.py
+++ b/supervisor/http.py
@@ -733,7 +733,7 @@ class logtail_handler:
         # the lack of a Content-Length header makes the outputter
         # send a 'Transfer-Encoding: chunked' response
 
-        request.push(tail_f_producer(request, logfile, 1024))
+        request.push(tail_f_producer(request, logfile, 1024).more())
 
         request.done()
 
@@ -764,7 +764,7 @@ class mainlogtail_handler:
         # the lack of a Content-Length header makes the outputter
         # send a 'Transfer-Encoding: chunked' response
 
-        request.push(tail_f_producer(request, logfile, 1024))
+        request.push(tail_f_producer(request, logfile, 1024).more())
 
         request.done()
 


### PR DESCRIPTION
Because forgot to give the contents via `tail_f_producer.more()`
