### PR TITLE
Create MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include supervisor/version.txt


### PR DESCRIPTION
To support the `bdist_rpm` setuptools command, a MANIFEST is needed to include supervisor/version.txt in the distribution (`sdist` does not capture this file by default).

This issue arises because `bdist_rpm` runs `setup.py` inside a fakeroot environment.

This change adds a MANIFEST.in template to the repo which references the needed `version.txt`
