### PR TITLE
Quit child processes when supervisor crashes (Linux only)

### DIFF
--- a/supervisor/process.py
+++ b/supervisor/process.py
@@ -286,14 +286,14 @@ class Subprocess:
             # supervisord from being sent to children.
             options.setpgrp()
 
-            # Send this process a stop signal if supervisor crashes.
+            # Send this process a kill signal if supervisor crashes.
             # Uses system call prctl(PR_SET_PDEATHSIG, <signal>).
             # This will only work on Linux.
             try:
                 import ctypes
                 import ctypes.util
                 libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library('c'))
-                libc.prctl(1, signal_number(self.config.stopsignal))
+                libc.prctl(1, signal.SIGKILL)
             except Exception, e:
                 options.logger.debug("Could not set parent death signal. "
                                      "This is expected if not running on Linux.")

--- a/supervisor/process.py
+++ b/supervisor/process.py
@@ -23,6 +23,7 @@ from supervisor.dispatchers import EventListenerStates
 from supervisor import events
 
 from supervisor.datatypes import RestartUnconditionally
+from supervisor.datatypes import signal_number
 
 from supervisor.socket_manager import SocketManager
 
@@ -284,6 +285,19 @@ class Subprocess:
             # Presumably it also prevents HUP, etc received by
             # supervisord from being sent to children.
             options.setpgrp()
+
+            # Send this process a stop signal if supervisor crashes.
+            # Uses system call prctl(PR_SET_PDEATHSIG, <signal>).
+            # This will only work on Linux.
+            try:
+                import ctypes
+                import ctypes.util
+                libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library('c'))
+                libc.prctl(1, signal_number(self.config.stopsignal))
+            except Exception, e:
+                options.logger.debug("Could not set parent death signal. "
+                                     "This is expected if not running on Linux.")
+
             self._prepare_child_fds()
             # sending to fd 2 will put this output in the stderr log
             msg = self.set_uid()


### PR DESCRIPTION
If supervisor crashes, its child processes left running and inherited by supervisor's parent process.  I've added a way to send these processes a stop signal if the parent goes away using prctl(PR_SET_PDEATHSIG, SIGTERM).  It only works on Linux.  On other platforms exceptions are caught and ignored.

I've not run it on anything besides Linux yet.

To test it, start supervisor then send it a kill -9.  The child process receives the SIGTERM as expected.