### PR TITLE
Add explicit dependency `setuptools-git`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ dist = setup(
     author_email = "chrism@plope.com",
     maintainer = "Mike Naberezny",
     maintainer_email = "mike@naberezny.com",
+    setup_requires = ['setuptools-git >= 0.3'],
     packages = find_packages(),
     install_requires = requires,
     extras_require = {'iterparse':['cElementTree >= 1.0.2']},


### PR DESCRIPTION
Since `setuptool-git` is needed to properly build a package distribution, it would be convenient to explicitly require this in the setup configuration.

The chosen version of setuptools-git (0.3) was copied from the setuptools-git README.
