### PR TITLE
Add very basic Linux control groups support

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -231,7 +231,8 @@ Process Control
              'exitstatus':     0,
              'stdout_logfile': '/path/to/stdout-log',
              'stderr_logfile': '/path/to/stderr-log',
-             'pid':            1}
+             'pid':            1,
+             'has_cgroups'     0}
 
         .. describe:: name
 
@@ -286,6 +287,10 @@ Process Control
             UNIX process ID (PID) of the process, or 0 if the process is not
             running.
 
+        .. describe:: has_cgroups
+
+            1 if the process was configured to attach to at least one control
+            group, or 0 if not.
 
     .. automethod:: getAllProcessInfo
 

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -794,6 +794,7 @@ class ServerOptions(Options):
         serverurl = get(section, 'serverurl', None)
         if serverurl and serverurl.strip().upper() == 'AUTO':
             serverurl = None
+        cgroups = list_of_strings(get(section, 'cgroups', None))
 
         umask = get(section, 'umask', None)
         if umask is not None:
@@ -883,7 +884,8 @@ class ServerOptions(Options):
                 exitcodes=exitcodes,
                 redirect_stderr=redirect_stderr,
                 environment=environment,
-                serverurl=serverurl)
+                serverurl=serverurl,
+                cgroups=cgroups)
 
             programs.append(pconfig)
 
@@ -1600,7 +1602,7 @@ class ProcessConfig(Config):
         'stderr_logfile_backups', 'stderr_logfile_maxbytes',
         'stderr_events_enabled',
         'stopsignal', 'stopwaitsecs', 'stopasgroup', 'killasgroup',
-        'exitcodes', 'redirect_stderr' ]
+        'exitcodes', 'redirect_stderr', 'cgroups' ]
     optional_param_names = [ 'environment', 'serverurl' ]
 
     def __init__(self, options, **params):

--- a/supervisor/process.py
+++ b/supervisor/process.py
@@ -289,6 +289,19 @@ class Subprocess:
             options.setpgrp()
             self._prepare_child_fds()
             # sending to fd 2 will put this output in the stderr log
+
+            # Attach the child to cgroups before dropping privileges
+            # (may need to be root to do this).
+            msg = self.attach_cgroups()
+            if msg:
+                cgroups = self.config.cgroups
+                s = 'supervisor: error attaching process to cgroups %s ' % cgroups
+                options.write(2, s)
+                options.write(2, "(%s)\n" % msg)
+                # It would be great to actually affect parent state here
+                # (i.e. the parent should know that we haven't actually
+                # attached), but this only logs.
+
             msg = self.set_uid()
             if msg:
                 uid = self.config.uid
@@ -490,6 +503,24 @@ class Subprocess:
             return
         msg = self.config.options.dropPrivileges(self.config.uid)
         return msg
+
+    def attach_cgroups(self):
+        # Doesn't undo in the event of partial failure (e.g. attach succeeds
+        # for one but not the other).
+        for cgroup in self.config.cgroups:
+            tasks_path = os.path.join(cgroup, "tasks")
+            if not os.path.isfile(tasks_path):
+                return "Can't find cgroup path %s" % tasks_path
+            try:
+                tasks = open(tasks_path, "w")
+                try:
+                    # We assume that we're only called during process creation,
+                    # so we're single-threaded and can write just our PID.
+                    tasks.write(str(self.config.options.get_pid()))
+                finally:
+                    tasks.close()
+            except IOError:
+                return "Couldn't attach process to cgroup %s" % tasks_path
 
     def __cmp__(self, other):
         # sort by priority

--- a/supervisor/rpcinterface.py
+++ b/supervisor/rpcinterface.py
@@ -527,6 +527,7 @@ class SupervisorNamespaceRPCInterface:
             'stdout_logfile':stdout_logfile,
             'stderr_logfile':stderr_logfile,
             'pid':process.pid,
+            'has_cgroups':int(len(process.config.cgroups) > 0),
             }
 
         description = self._interpretProcessInfo(info)

--- a/supervisor/tests/base.py
+++ b/supervisor/tests/base.py
@@ -484,7 +484,7 @@ class DummyPConfig:
                  stderr_logfile_backups=0, stderr_logfile_maxbytes=0,
                  redirect_stderr=False,
                  stopsignal=None, stopwaitsecs=10, stopasgroup=False, killasgroup=False,
-                 exitcodes=(0,2), environment=None, serverurl=None):
+                 exitcodes=(0,2), environment=None, serverurl=None, cgroups=[]):
         self.options = options
         self.name = name
         self.command = command
@@ -518,6 +518,7 @@ class DummyPConfig:
         self.umask = umask
         self.autochildlogs_created = False
         self.serverurl = serverurl
+        self.cgroups = cgroups
 
     def create_autochildlogs(self):
         self.autochildlogs_created = True

--- a/supervisor/tests/test_process.py
+++ b/supervisor/tests/test_process.py
@@ -904,6 +904,29 @@ class SubprocessTests(unittest.TestCase):
         self.assertEqual(options.privsdropped, 1)
         self.assertEqual(msg, None)
 
+    def test_attach_cgroups(self):
+        cgroups = ["/tmp/test_cg1", "/tmp/test_cg2"]
+        for cg in cgroups:
+            if os.path.exists(cg):
+                os.rmdir(cg)
+            os.makedirs(cg)
+            open(os.path.join(cg, "tasks"), "w").close()
+
+        options = DummyOptions()
+        config = DummyPConfig(options, 'test', '/test', cgroups=cgroups)
+        instance = self._makeOne(config)
+        msg = instance.attach_cgroups()
+        for cg in cgroups:
+            tasks_path = os.path.join(cg, "tasks")
+            tasks = open(tasks_path)
+            try:
+                self.assertEqual(tasks.read().strip(), str(os.getpid()))
+            finally:
+                tasks.close()
+            os.remove(tasks_path)
+            os.rmdir(cg)
+        self.assertEqual(msg, None)
+
     def test_cmp_bypriority(self):
         options = DummyOptions()
         config = DummyPConfig(options, 'notthere', '/notthere',

--- a/supervisor/tests/test_supervisord.py
+++ b/supervisor/tests/test_supervisord.py
@@ -261,7 +261,8 @@ class SupervisordTests(unittest.TestCase):
                 'stopsignal': None, 'stopwaitsecs': 10,
                 'stopasgroup': False,
                 'killasgroup': False,
-                'exitcodes': (0,2), 'environment': None, 'serverurl': None }
+                'exitcodes': (0,2), 'environment': None, 'serverurl': None,
+                'cgroups': None }
             result.update(params)
             return ProcessConfig(options, **result)
 


### PR DESCRIPTION
Control groups (cgroups) are a Linux kernel feature that can be used for
resource management and isolation between processes. In my case, I have an
out-of-band application that manages the cgroups themselves, but as I use
supervisor to manage process lifecycle, it's well positioned to attach
processes to cgroups, and to reattach them if they're autorestarted.

Here we do that, with two main changes:
1. After forking a process, supervisor will attach it to every desired
   cgroup by writing its pid to each 'tasks' pseudofile. Note that cgroup
   membership is per-thread (not per-process), but at this stage in the
   process' life, it should be single threaded.
2. When queried for process information, supervisor will also mention
   if the process has cgroups or not. Ideally we'd take into account whether
   attaching actually succeeded, but effecting that change in the parent is
   tough from the forked child.
