### PR TITLE
Sort the included files

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -537,7 +537,7 @@ class ServerOptions(Options):
                 base = '.'
             for pattern in files:
                 pattern = os.path.join(base, pattern)
-                for filename in glob.glob(pattern):
+                for filename in sorted(glob.glob(pattern)):
                     self.parse_warnings.append(
                         'Included extra file "%s" during parsing' % filename)
                     try:


### PR DESCRIPTION
glob.glob returns files in arbitrary order. I have a scenario where I would need reliable ordering.
