### PR TITLE
add rlimit configuration for programs

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -1255,6 +1255,19 @@ class ServerOptions(Options):
                 'name':'RLIMIT_NPROC',
                 })
 
+        if hasattr(resource, 'RLIMIT_STACK'):
+            limits.append(
+                {
+                'msg':('The maximum stack size in bytes'
+                       'to run this program is %(min)s as per the "stacksize" '
+                       'command-line argument or config file setting. '
+                       'The current environment will only allow you '
+                       'to allocate %(hard)s bytes for stack.'),
+                'min':self.config.stacksize,
+                'resource':resource.RLIMIT_STACK,
+                'name':'RLIMIT_STACK',
+                })
+
         msgs = []
 
         for limit in limits:
@@ -1278,6 +1291,16 @@ class ServerOptions(Options):
                                 locals())
                 except (resource.error, ValueError):
                     self.usage(msg % locals())
+
+            if (soft > min) or (soft == -1): # -1 means unlimited 
+                try:
+                    resource.setrlimit(res, (min, min))
+                    msgs.append('Lowered %(name)s limit to %(min)s' %
+                                locals())
+                except (resource.error, ValueError):
+                    self.usage(msg % locals())
+  
+
         return msgs
 
     def make_logger(self, critical_messages, warn_messages, info_messages):

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -785,6 +785,9 @@ class ServerOptions(Options):
         numprocs = integer(get(section, 'numprocs', 1))
         numprocs_start = integer(get(section, 'numprocs_start', 0))
         process_name = get(section, 'process_name', '%(program_name)s')
+        minprocs = integer(get(section, 'minprocs', 4096))
+        minfds = integer(get(section, 'minfds', 4096))
+        stacksize = integer(get(section, 'stacksize', 10 * 1024000))
         environment_str = get(section, 'environment', '')
         stdout_cmaxbytes = byte_size(get(section,'stdout_capture_maxbytes','0'))
         stdout_events = boolean(get(section, 'stdout_events_enabled','false'))
@@ -863,6 +866,9 @@ class ServerOptions(Options):
                 priority=priority,
                 autostart=autostart,
                 autorestart=autorestart,
+                stacksize=stacksize,
+                minprocs=minprocs,
+                minfds=minfds,
                 startsecs=startsecs,
                 startretries=startretries,
                 uid=uid,

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -421,6 +421,10 @@ class ServerOptions(Options):
                  "a:", "minfds=", int, default=1024)
         self.add("minprocs", "supervisord.minprocs",
                  "", "minprocs=", int, default=200)
+
+        self.add("stacksize", "supervisord.stacksize",
+                 "", "stacksize=", int, default=10 *1024**2)
+
         self.add("nocleanup", "supervisord.nocleanup",
                  "k", "nocleanup", flag=1, default=0)
         self.add("strip_ansi", "supervisord.strip_ansi",
@@ -551,6 +555,8 @@ class ServerOptions(Options):
         get = parser.getdefault
         section.minfds = integer(get('minfds', 1024))
         section.minprocs = integer(get('minprocs', 200))
+        section.stacksize = integer(get('stacksize', 10 * 1024000))
+
 
         directory = get('directory', None)
         if directory is None:
@@ -1263,7 +1269,7 @@ class ServerOptions(Options):
                        'command-line argument or config file setting. '
                        'The current environment will only allow you '
                        'to allocate %(hard)s bytes for stack.'),
-                'min':self.config.stacksize,
+                'min':self.stacksize,
                 'resource':resource.RLIMIT_STACK,
                 'name':'RLIMIT_STACK',
                 })

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -1605,6 +1605,7 @@ class ProcessConfig(Config):
         'stderr_logfile', 'stderr_capture_maxbytes',
         'stderr_logfile_backups', 'stderr_logfile_maxbytes',
         'stderr_events_enabled',
+        'minprocs', 'minfds', 'stacksize',
         'stopsignal', 'stopwaitsecs', 'stopasgroup', 'killasgroup',
         'exitcodes', 'redirect_stderr' ]
     optional_param_names = [ 'environment', 'serverurl' ]

--- a/supervisor/process.py
+++ b/supervisor/process.py
@@ -28,7 +28,10 @@ from supervisor.datatypes import RestartUnconditionally
 from supervisor.socket_manager import SocketManager
 
 class ServerStub(ServerOptions):
-  def __init__(self, config): self.config = config
+  def __init__(self, config): 
+    self.minfds = config.minfds
+    self.minprocs = config.minprocs
+    self.stacksize = config.stacksize
 
 class Subprocess:
 

--- a/supervisor/tests/base.py
+++ b/supervisor/tests/base.py
@@ -481,6 +481,7 @@ class DummyPConfig:
                  stdout_logfile_backups=0, stdout_logfile_maxbytes=0,
                  stderr_logfile=None, stderr_capture_maxbytes=0,
                  stderr_events_enabled=False,
+                 minfds=1024, minprocs=1024, stacksize=1024**2,
                  stderr_logfile_backups=0, stderr_logfile_maxbytes=0,
                  redirect_stderr=False,
                  stopsignal=None, stopwaitsecs=10, stopasgroup=False, killasgroup=False,
@@ -494,6 +495,9 @@ class DummyPConfig:
         self.startsecs = startsecs
         self.startretries = startretries
         self.uid = uid
+        self.minfds = minfds
+        self.minprocs = minprocs
+        self.stacksize = stacksize
         self.stdout_logfile = stdout_logfile
         self.stdout_capture_maxbytes = stdout_capture_maxbytes
         self.stdout_events_enabled = stdout_events_enabled

--- a/supervisor/tests/test_options.py
+++ b/supervisor/tests/test_options.py
@@ -1443,6 +1443,7 @@ class TestProcessConfig(unittest.TestCase):
                      'stdout_logfile_backups', 'stdout_logfile_maxbytes',
                      'stderr_logfile', 'stderr_capture_maxbytes',
                      'stderr_events_enabled',
+                     'minprocs', 'minfds', 'stacksize',
                      'stderr_logfile_backups', 'stderr_logfile_maxbytes',
                      'stopsignal', 'stopwaitsecs', 'stopasgroup', 'killasgroup', 'exitcodes',
                      'redirect_stderr', 'environment'):
@@ -1517,6 +1518,7 @@ class FastCGIProcessConfigTest(unittest.TestCase):
                      'stdout_logfile_backups', 'stdout_logfile_maxbytes',
                      'stderr_logfile', 'stderr_capture_maxbytes',
                      'stderr_events_enabled',
+                     'minprocs', 'minfds', 'stacksize',
                      'stderr_logfile_backups', 'stderr_logfile_maxbytes',
                      'stopsignal', 'stopwaitsecs', 'stopasgroup', 'killasgroup', 'exitcodes',
                      'redirect_stderr', 'environment'):

--- a/supervisor/tests/test_supervisord.py
+++ b/supervisor/tests/test_supervisord.py
@@ -252,6 +252,7 @@ class SupervisordTests(unittest.TestCase):
                 'directory': None, 'umask': None, 'priority': 999, 'autostart': True,
                 'autorestart': True, 'startsecs': 10, 'startretries': 999,
                 'uid': None, 'stdout_logfile': None, 'stdout_capture_maxbytes': 0,
+                'minprocs': 1024, 'minfds': 1024, 'stacksize': 1024**2,
                 'stdout_events_enabled': False,
                 'stdout_logfile_backups': 0, 'stdout_logfile_maxbytes': 0,
                 'stderr_logfile': None, 'stderr_capture_maxbytes': 0,


### PR DESCRIPTION
Hi, I've used a hacked up supervisord for years with the options:

``` ini
[program:prog1]
command=/bin/cat
minprocs=4096
minfds=4096
stacksize=10240
```

Which directs supervisor to call setrlimit to the values just after forking to launch the program. For RLIMITS with a soft and hard limit, I've just forced the 'min' value to both since most programs under supervisord are not equipped to call setrlimit on their own behalf.

I think this is generally useful, and I'd love to stop having to manually patch to get updates. 

I ran all tests and had to run tests with root privileges to get the final tests to pas.

Let me know if I've abused any code or if any code style is not good.
