### PR TITLE
workaround to run the XMLRPC client on windows

### DIFF
--- a/supervisor/http.py
+++ b/supervisor/http.py
@@ -4,7 +4,10 @@ import time
 import sys
 import socket
 import errno
-import pwd
+try:
+    import pwd
+except ImportError:
+    import getpass as pwd
 import urllib
 
 try:


### PR DESCRIPTION
Workaround to make the XMLRPC client usable on Windows.
