### PR TITLE
Issue with dict_of_key_value_pairs on Python < 2.7

### DIFF
--- a/supervisor/tests/test_datatypes.py
+++ b/supervisor/tests/test_datatypes.py
@@ -143,6 +143,11 @@ class DatatypesTest(unittest.TestCase):
         self.assertRaises(ValueError,
                           datatypes.dict_of_key_value_pairs, kvp)
 
+    def test_dict_of_key_value_pairs_unicode(self):
+        actual = datatypes.dict_of_key_value_pairs(u'foo=bar,baz=qux')
+        expected = {'foo': 'bar', 'baz': 'qux'}
+        self.assertEqual(actual, expected)
+
     def test_logfile_name_returns_none_for_none_values(self):
         for thing in datatypes.LOGFILE_NONES:
             actual = datatypes.logfile_name(thing)


### PR DESCRIPTION
If you pass a unicode string to `dict_of_key_value_pairs` in Python < 2.7, it raises a `ValueError` because of an issue in shlex (probably this one http://bugs.python.org/issue1170)

Here's a test to reproduce the bug.

Two fix ideas:
- encode unicode strings in `dict_of_key_value_pairs` (utf-8 works fine here)
- assert that the argument must not be of type `unicode` in Python < 2.7
