### PR TITLE
Re-read config on start.

### DIFF
--- a/supervisor/supervisorctl.py
+++ b/supervisor/supervisorctl.py
@@ -644,7 +644,7 @@ class DefaultControllerPlugin(ControllerPluginBase):
     def do_start(self, arg):
         if not self.ctl.upcheck():
             return
-
+        self.do_reload(arg)
         names = arg.strip().split()
         supervisor = self.ctl.get_supervisor()
 


### PR DESCRIPTION
Call do_reload from do_start so config files are re-read.
Supervisorctl restart <foo> will restart <foo> but if <foo> has been changed on disk, it won't actually run foo. Fix this by forcing a re-read on start.

I am doubtful that _anyone_ uses the current behavior as a feature.
