### PR TITLE
Stdout/Stderr logging

### DIFF
--- a/supervisor/loggers.py
+++ b/supervisor/loggers.py
@@ -337,6 +337,12 @@ def getLogger(filename, level, fmt, rotating=False, maxbytes=0, backups=0,
     elif filename == 'syslog':
         handlers.append(SyslogHandler())
 
+    elif filename == '/dev/stdout':
+        handlers.append(StreamHandler(sys.stdout))
+
+    elif filename == '/dev/stderr':
+        handlers.append(StreamHandler(sys.stderr))
+
     else:
         if rotating is False:
             handlers.append(FileHandler(filename))


### PR DESCRIPTION
There is a legit use-case for logging to stdout/stderr: If supervisor is
run on a platform like Heroku that only supports capturing stdout/stderr
(but no logfiles or syslog), applications started by it should at least
have a chance at logging something if supervisord is run as a foreground
process.

This could be achieved by passing /dev/stdout and /dev/stderr as the
respective logfiles, but these may not be opened or rotated. This simple
patch detects if one of these files has been specified and chooses a
StreamHandler instead of a FileHandler to service them.
