### PR TITLE
Avoid non-zero exit status when restarting non-existed process groups.

### DIFF
--- a/supervisor/supervisorctl.py
+++ b/supervisor/supervisorctl.py
@@ -729,10 +729,16 @@ class DefaultControllerPlugin(ControllerPluginBase):
             for name in names:
                 group_name, process_name = split_namespec(name)
                 if process_name is None:
-                    results = supervisor.stopProcessGroup(group_name)
-                    for result in results:
-                        result = self._stopresult(result)
-                        self.ctl.output(result)
+                    try:
+                        results = supervisor.stopProcessGroup(group_name)
+                        for result in results:
+                            result = self._stopresult(result)
+                            self.ctl.output(result)
+                    except xmlrpclib.Fault, e:
+                        error = self._startresult({'status': e.faultCode,
+                                                   'name': name,
+                                                   'description': e.faultString})
+                        self.ctl.output(error)
                 else:
                     try:
                         result = supervisor.stopProcess(name)


### PR DESCRIPTION
Handle the BAD_NAME exception the server raised and process with the same strategy used for single process names.
