### PR TITLE
Lower select timeout

### DIFF
--- a/supervisor/supervisord.py
+++ b/supervisor/supervisord.py
@@ -179,7 +179,7 @@ class Supervisor:
 
     def runforever(self):
         events.notify(events.SupervisorRunningEvent())
-        timeout = 1 # this cannot be fewer than the smallest TickEvent (5)
+        timeout = 0.1
 
         socket_map = self.options.get_socket_map()
 


### PR DESCRIPTION
The various deferring classes in http.py would try to delay by 0.1
seconds when data was not yet ready.  However, since the select
timeout was 1 second, we'd end up delaying that long, instead.  This
amounted to each start or stop command taking 1 second to complete.

The comment about the minimum timeout appears to have never been
true.
