### PR TITLE
Adding MANIFEST.in to include static files like version.txt

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include supervisor/version.txt


### PR DESCRIPTION
setup.py uses find_packages to look for the files to include when generating the .egg file, and version.txt seems to not be included.

You can see that looking into the supervisor.egg-info/SOURCES.txt metadata, the version.txt file is missing.

In supervisor/options.py file line 56 that file is read, and when the code pass through that lines, supervisord fails.

Adding that file makes setup.py includes version.txt into the .egg file.
