### PR TITLE
copied & modified config 'include' code from ServerOptions to ClientOpti...

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -1516,6 +1516,25 @@ class ClientOptions(Options):
         config.mysection = 'supervisorctl'
         config.readfp(fp)
         sections = config.sections()
+
+        if 'include' in sections:
+            if not config.has_option('include', 'files'):
+                raise ValueError(".ini file has [include] section, but no "
+                "files setting")
+            files = config.get('include', 'files')
+            files = files.split()
+            if hasattr(fp, 'name'):
+                base = os.path.dirname(os.path.abspath(fp.name))
+            else:
+                base = '.'
+            for pattern in files:
+                pattern = os.path.join(base, pattern)
+                for filename in glob.glob(pattern):
+                    try:
+                        config.read(filename)
+                    except ConfigParser.ParsingError, why:
+                        raise ValueError(str(why))
+
         if not 'supervisorctl' in sections:
             raise ValueError,'.ini file does not include supervisorctl section'
         serverurl = config.getdefault('serverurl', 'http://localhost:9001')


### PR DESCRIPTION
Being able to extend the xmlrpc interface via a custom namespace using a config "drop file" is _really_ nice.

It would be similarly nice if this was paired with the ability to extend the supervisorctl client in a similar fashion. While one **can** add "plugins" by modifying the root supervisord.conf, the ClientOptions class does not parse include files in the same way as ServerOptions. This pull request changes that by copying, with some modifications (due to minor differences between the two classes), the "include" code from ServerOptions to ClientOptions. Thus, one can extend supervisorctl to match xmlrpc extensions by (assuming the main conf has an `[include]` section with `files = /etc/supervisor.d/*.conf` in it) creating an /etc/supervisor.d/foo.conf file containing:

```
[ctlplugin:foo]
supervisor.ctl_factory = mynamespace:mymodule.Controller
```

(mymodule would then need to provide a `Controller` class which inherits from `supervisor.supervisorctl.ControllerPluginBase`).
