### PR TITLE
Better syslog configuration and output

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -71,6 +71,9 @@
 
 - Removed medusa files not used by Supervisor.
 
+- New ``syslog`` boolean option in the ``[supervisord]`` section.  Similar
+  feature for top-level supervisor.  See docs for more.  Patch by Sam Vilain.
+
 3.1.1 (2014-08-11)
 ------------------
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -204,6 +204,19 @@ follows.
 
   *Introduced*: 3.0
 
+``syslog``
+
+  If true, then supervisor will send all of its messages to syslog.
+  Messages are currently sent with the default facility (user) and a
+  range of priorities, with a tag of "supervisord" and a process ID.
+
+  *Default*:  false
+
+  *Required*:  No.
+
+  *Introduced*: 3.1a1
+
+
 ``logfile_maxbytes``
 
   The maximum number of bytes that may be consumed by the activity log

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -877,6 +877,8 @@ where specified.
 ``stdout_syslog``
 
   If true, stdout will be directed to syslog along with the process name.
+  Messages are sent with a user priority, a tag of the process name
+  without PID, and an additional prefix of ``stdout:``
 
   *Default*: False
 
@@ -954,6 +956,8 @@ where specified.
 ``stderr_syslog``
 
   If true, stderr will be directed to syslog along with the process name.
+  Messages are sent with a user priority, a tag of the process name
+  without PID, and an additional prefix of ``stderr``
 
   *Default*: False
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -207,8 +207,8 @@ follows.
 ``syslog``
 
   If true, then supervisor will send all of its messages to syslog.
-  Messages are currently sent with the default facility (user) and a
-  range of priorities, with a tag of "supervisord" and a process ID.
+  Messages are currently sent with the facility 'daemon' and a
+  range of priorities, a tag of "supervisord" and a process ID.
 
   *Default*:  false
 
@@ -877,8 +877,9 @@ where specified.
 ``stdout_syslog``
 
   If true, stdout will be directed to syslog along with the process name.
-  Messages are sent with a user priority, a tag of the process name
-  without PID, and an additional prefix of ``stdout:``
+  Messages are sent with 'user' facility and priority 'info', and with
+  the tag set to the process name, currently without the PID of the
+  subprocess included.
 
   *Default*: False
 
@@ -955,9 +956,10 @@ where specified.
 
 ``stderr_syslog``
 
-  If true, stderr will be directed to syslog along with the process name.
-  Messages are sent with a user priority, a tag of the process name
-  without PID, and an additional prefix of ``stderr``
+  If true, stderr will be directed to syslog along with the process
+  name.  Messages are sent with 'user' facility and priority 'notice',
+  and with the tag set to the process name, currently without the PID
+  of the subprocess included.
 
   *Default*: False
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -210,6 +210,14 @@ follows.
   Messages are currently sent with the facility 'daemon' and a
   range of priorities, a tag of "supervisord" and a process ID.
 
+  Instead of a simple ``true`` or ``false``, this can also be set to a
+  syslog facility, like ``local0``, to override the default of
+  ``daemon``.  All messages can be forced to a single severity using a
+  value like ``local0.warning``.
+
+  Facilities can also be specified numerically, such as ``10`` to mean
+  ``authpriv``.
+
   *Default*:  false
 
   *Required*:  No.
@@ -881,6 +889,9 @@ where specified.
   the tag set to the process name, currently without the PID of the
   subprocess included.
 
+  The syslog facility, or facility and severity can be adjusted by
+  specifying a syslog facility such as ``local1`` or ``local1.notice``.
+
   *Default*: False
 
   *Required*:  No.
@@ -960,6 +971,9 @@ where specified.
   name.  Messages are sent with 'user' facility and priority 'notice',
   and with the tag set to the process name, currently without the PID
   of the subprocess included.
+
+  The syslog facility, or facility and severity can be adjusted by
+  specifying a syslog facility such as ``local1`` or ``local1.err``.
 
   *Default*: False
 

--- a/supervisor/dispatchers.py
+++ b/supervisor/dispatchers.py
@@ -146,8 +146,8 @@ class POutputDispatcher(PDispatcher):
             backups=backups)
 
         if getattr(config, '%s_syslog' % channel, False):
-            fmt = config.name + ' %(message)s'
-            loggers.handle_syslog(self.mainlog, fmt)
+            fmt = channel + ": %(message)s"
+            loggers.handle_syslog(self.mainlog, fmt, tag=config.name)
 
     def removelogs(self):
         for log in (self.mainlog, self.capturelog):

--- a/supervisor/dispatchers.py
+++ b/supervisor/dispatchers.py
@@ -146,8 +146,11 @@ class POutputDispatcher(PDispatcher):
             backups=backups)
 
         if getattr(config, '%s_syslog' % channel, False):
-            fmt = channel + ": %(message)s"
-            loggers.handle_syslog(self.mainlog, fmt, tag=config.name)
+            fmt = "%(message)s"
+            #facility = getattr(config, '%s_syslog_facility', 'user')
+            priority = "notice" if channel == "stderr" else "info"
+            loggers.handle_syslog(self.mainlog, fmt, tag=config.name,
+                                  facility="user", priority=priority)
 
     def removelogs(self):
         for log in (self.mainlog, self.capturelog):

--- a/supervisor/dispatchers.py
+++ b/supervisor/dispatchers.py
@@ -147,10 +147,13 @@ class POutputDispatcher(PDispatcher):
 
         if getattr(config, '%s_syslog' % channel, False):
             fmt = "%(message)s"
-            #facility = getattr(config, '%s_syslog_facility', 'user')
             priority = "notice" if channel == "stderr" else "info"
+            facility = getattr(config, '%s_syslog_facility' % channel, 'user')
+            priority = getattr(
+                config, '%s_syslog_priority' % channel, priority
+            )
             loggers.handle_syslog(self.mainlog, fmt, tag=config.name,
-                                  facility="user", priority=priority)
+                                  facility=facility, priority=priority)
 
     def removelogs(self):
         for log in (self.mainlog, self.capturelog):

--- a/supervisor/loggers.py
+++ b/supervisor/loggers.py
@@ -12,6 +12,7 @@ import errno
 import sys
 import time
 import traceback
+import types
 
 from supervisor.compat import syslog
 from supervisor.compat import long
@@ -336,11 +337,13 @@ level_to_syslog = {
 class SyslogHandler(Handler):
     def __init__(self, tag=None, pid=False, facility="daemon", priority=None):
         self.tag = tag or "supervisord"
-        self.facility = (getattr(syslog, "LOG_" + facility.upper(), None),)
-        self.priority = (
-            priority if priority is None or isinstance(priority, int) else
-            getattr(syslog, "LOG_" + priority.upper(), None)
-        )
+        def _int_string_or_none(val):
+            return val if isinstance(val, (int, type(None))) else (
+                getattr(syslog, "LOG_" + val.upper(), None)
+            )
+
+        self.priority = _int_string_or_none(priority)
+        self.facility = _int_string_or_none(facility)
         self.options = syslog.LOG_PID if pid else 0
         assert 'syslog' in globals(), "Syslog module not present"
 
@@ -361,7 +364,7 @@ class SyslogHandler(Handler):
                 record.level, syslog.LOG_WARNING
             )
             message = params['message']
-            syslog.openlog(self.tag, self.options, *self.facility)
+            syslog.openlog(self.tag, self.options, self.facility)
             for line in message.rstrip('\n').split('\n'):
                 params['message'] = line
                 msg = self.fmt % params

--- a/supervisor/loggers.py
+++ b/supervisor/loggers.py
@@ -324,9 +324,10 @@ class Logger:
         raise NotImplementedError
 
 class SyslogHandler(Handler):
-    def __init__(self):
-        Handler.__init__(self)
-        assert syslog is not None, "Syslog module not present"
+    def __init__(self, tag=None, pid=False):
+        self.tag = tag or "supervisord"
+        self.options = syslog.LOG_PID if pid else 0
+        assert 'syslog' in globals(), "Syslog module not present"
 
     def close(self):
         pass
@@ -342,6 +343,7 @@ class SyslogHandler(Handler):
         try:
             params = record.asdict()
             message = params['message']
+            syslog.openlog(self.tag, self.options)
             for line in message.rstrip('\n').split('\n'):
                 params['message'] = line
                 msg = self.fmt % params
@@ -373,8 +375,8 @@ def handle_stdout(logger, fmt):
     handler.setLevel(logger.level)
     logger.addHandler(handler)
 
-def handle_syslog(logger, fmt):
-    handler = SyslogHandler()
+def handle_syslog(logger, fmt, tag=None, show_pid=None):
+    handler = SyslogHandler(tag, show_pid)
     handler.setFormat(fmt)
     handler.setLevel(logger.level)
     logger.addHandler(handler)

--- a/supervisor/loggers.py
+++ b/supervisor/loggers.py
@@ -380,14 +380,10 @@ def handle_syslog(logger, fmt):
     logger.addHandler(handler)
 
 def handle_file(logger, filename, fmt, rotating=False, maxbytes=0, backups=0):
-    if filename == 'syslog':
-        handler = SyslogHandler()
-
+    if rotating is False:
+        handler = FileHandler(filename)
     else:
-        if rotating is False:
-            handler = FileHandler(filename)
-        else:
-            handler = RotatingFileHandler(filename, 'a', maxbytes, backups)
+        handler = RotatingFileHandler(filename, 'a', maxbytes, backups)
 
     handler.setFormat(fmt)
     handler.setLevel(logger.level)

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -943,7 +943,7 @@ class ServerOptions(Options):
                 logfiles[mb_key] = maxbytes
 
                 sy_key = '%s_syslog' % k
-                syslog = boolean(get(section, sy_key, False))
+                syslog = boolean(get(section, sy_key, logfiles[n] == "syslog"))
                 logfiles[sy_key] = syslog
 
                 if lf_val is Automatic and not maxbytes:
@@ -1405,14 +1405,18 @@ class ServerOptions(Options):
         self.logger = loggers.getLogger(self.loglevel)
         if self.nodaemon:
             loggers.handle_stdout(self.logger, format)
-        loggers.handle_file(
-            self.logger,
-            self.logfile,
-            format,
-            rotating=True,
-            maxbytes=self.logfile_maxbytes,
-            backups=self.logfile_backups,
-        )
+        if self.syslog or self.logfile == "syslog":
+            loggers.handle_syslog(self.logger, '%(message)s',
+                                  tag="supervisord", show_pid=True)
+        else:
+            loggers.handle_file(
+                self.logger,
+                self.logfile,
+                format,
+                rotating=True,
+                maxbytes=self.logfile_maxbytes,
+                backups=self.logfile_backups,
+            )
         for msg in critical_messages:
             self.logger.critical(msg)
         for msg in warn_messages:

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -405,6 +405,7 @@ class ServerOptions(Options):
     sockchmod = None
     logfile = None
     loglevel = None
+    syslog = None
     pidfile = None
     passwdfile = None
     nodaemon = None
@@ -428,6 +429,8 @@ class ServerOptions(Options):
                  existing_directory)
         self.add("logfile", "supervisord.logfile", "l:", "logfile=",
                  existing_dirpath, default="supervisord.log")
+        self.add("syslog", "supervisord.syslog", "L", "syslog",
+                 flag=1, default=0)
         self.add("logfile_maxbytes", "supervisord.logfile_maxbytes",
                  "y:", "logfile_maxbytes=", byte_size,
                  default=50 * 1024 * 1024) # 50MB
@@ -488,7 +491,11 @@ class ServerOptions(Options):
         else:
             logfile = section.logfile
 
-        self.logfile = normalize_path(logfile)
+        if self.syslog or logfile == 'syslog':
+            self.logfile = "syslog"
+            self.syslog = True
+        else:
+            self.logfile = normalize_path(logfile)
 
         if self.pidfile:
             pidfile = self.pidfile
@@ -614,6 +621,7 @@ class ServerOptions(Options):
 
         section.user = get('user', None)
         section.umask = octal_type(get('umask', '022'))
+        section.syslog = boolean(get('syslog', "false"))
         section.logfile = existing_dirpath(get('logfile', 'supervisord.log'))
         section.logfile_maxbytes = byte_size(get('logfile_maxbytes', '50MB'))
         section.logfile_backups = integer(get('logfile_backups', 10))

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -1407,7 +1407,8 @@ class ServerOptions(Options):
             loggers.handle_stdout(self.logger, format)
         if self.syslog or self.logfile == "syslog":
             loggers.handle_syslog(self.logger, '%(message)s',
-                                  tag="supervisord", show_pid=True)
+                                  tag="supervisord", show_pid=True,
+                                  facility="daemon")
         else:
             loggers.handle_file(
                 self.logger,

--- a/supervisor/tests/test_datatypes.py
+++ b/supervisor/tests/test_datatypes.py
@@ -251,6 +251,18 @@ class RangeCheckedConversionTests(unittest.TestCase):
         conversion = self._makeOne(lambda *arg: 1, 0, 0)
         self.assertRaises(ValueError, conversion, None)
 
+    def test_syslog_returns_values(self):
+        for x, y in {
+            None: (None, None),
+            "daemon": ("daemon", None),
+            "user.err": ("daemon", "err"),
+        }.items():
+            self.assert_(datatypes.syslog_target(x), y)
+
+    def test_url_accepts_urlparse_recognized_scheme_with_netloc(self):
+        good_url = 'http://localhost:9001'
+        self.assertEqual(datatypes.url(good_url), good_url)
+
     def test_passes(self):
         conversion = self._makeOne(lambda *arg: 0, 0, 0)
         self.assertEqual(conversion(0), 0)

--- a/supervisor/tests/test_options.py
+++ b/supervisor/tests/test_options.py
@@ -674,7 +674,7 @@ class ServerOptionsTests(unittest.TestCase):
 
         [program:cat1]
         command=/bin/cat
-        stdout_logfile=/tmp/cat.log
+        stdout_logfile=syslog
 
         [program:cat2syslog]
         command=/bin/cat""")
@@ -686,6 +686,15 @@ class ServerOptionsTests(unittest.TestCase):
         options = instance.configroot.supervisord
         self.assertTrue(options.syslog)
         self.assertEqual(instance.logfile, 'syslog')
+
+        cat1 = options.process_group_configs[0]
+        proc1 = cat1.process_configs[0]
+        self.assertEqual(proc1.stdout_logfile, 'syslog')
+        self.assertEqual(proc1.stdout_syslog, True)
+
+        cat2 = options.process_group_configs[1]
+        proc2 = cat2.process_configs[0]
+        self.assertEqual(proc2.stdout_syslog, False)
 
         s = s.replace("syslog=true", "logfile=syslog")
 

--- a/supervisor/tests/test_options.py
+++ b/supervisor/tests/test_options.py
@@ -413,6 +413,7 @@ class ServerOptionsTests(unittest.TestCase):
         backofflimit=10
         user=root
         umask=022
+        syslog=false
         logfile=supervisord.log
         logfile_maxbytes=1000MB
         logfile_backups=5
@@ -662,6 +663,39 @@ class ServerOptionsTests(unittest.TestCase):
         instance.realize(args=[])
         options = instance.configroot.supervisord
         self.assertEqual(options.identifier, 'foo')
+
+    def test_syslog_options(self):
+        s = lstrip("""
+        [supervisord]
+        syslog=true
+        logfile_maxbytes=1000MB
+        logfile_backups=5
+        loglevel=error
+
+        [program:cat1]
+        command=/bin/cat
+        stdout_logfile=/tmp/cat.log
+
+        [program:cat2syslog]
+        command=/bin/cat""")
+
+        fp = StringIO(s)
+        instance = self._makeOne()
+        instance.configfile = fp
+        instance.realize(args=[])
+        options = instance.configroot.supervisord
+        self.assertTrue(options.syslog)
+        self.assertEqual(instance.logfile, 'syslog')
+
+        s = s.replace("syslog=true", "logfile=syslog")
+
+        instance = self._makeOne()
+        instance.configfile = fp
+        fp.seek(0)
+        instance.realize(args=[])
+        options = instance.configroot.supervisord
+        self.assertTrue(options.syslog)
+        self.assertEqual(instance.logfile, 'syslog')
 
     def test_reload(self):
         text = lstrip("""\


### PR DESCRIPTION
Hi there, thanks for the recent rework in the syslog support.  This is a set of changes which make the syslog output a bit better, reaching this:

```
    Sep 19 10:18:46.285916 Herman daemon.notice supervisord[5296]: supervisord started with pid 5296
    Sep 19 10:18:47.288994 Herman daemon.notice supervisord[5296]: spawned: 'vmstat' with pid 5299
    Sep 19 10:18:47.291366 Herman daemon.notice supervisord[5296]: spawned: 'badvmstat' with pid 5300
    Sep 19 10:18:47.297447 Herman   user.info   vmstat: procs -----------memory---------- ---swap-- -----io---- -system-- ----cpu----
    Sep 19 10:18:47.298812 Herman   user.info   vmstat:  r  b   swpd   free   buff  cache   si   so    bi    bo   in   cs us sy id wa
    Sep 19 10:18:47.299112 Herman   user.info   vmstat:  3  0      0 4874284 244368 1695416    0    0    63    20   62  191  1  0 98  1
    Sep 19 10:18:47.299428 Herman   user.notice badvmstat: vmstat: failed to parse argument: '5;'
    Sep 19 10:18:47.299866 Herman daemon.notice supervisord[5296]: exited: badvmstat (exit status 1; not expected)
    Sep 19 10:18:48.298243 Herman   user.info   vmstat:  0  0      0 4863852 244368 1702904    0    0     0     0 1437 8074  4  3 93  0
    Sep 19 10:18:48.298447 Herman daemon.notice supervisord[5296]: success: vmstat entered RUNNING state, process has stayed up for > than 1 seconds (startse
    Sep 19 10:18:49.298594 Herman   user.info   vmstat:  0  0      0 4863528 244368 1703152    0    0     0     0  737 1475  1  1 99  0
      ...
    Sep 19 10:19:13.488894 Herman daemon.warning supervisord[5296]: received SIGINT indicating exit request
```

Along the lines of the new "stdout_syslog" and "stderr_syslog" boolean values, I have created a new "syslog" top-level configuration, which is configured identically.  Additionally, there are now reasonable defaults for syslog facility and priority (shown in the above, but not logged by default by eg rsyslog).  Finally, if you care, you can select the syslog channel (192 to choose from!) yourself for each stream by putting the channel there instead of "true" in any of the `*syslog` config settings.

Closes issue #162 
