### PR TITLE
Add exit codes to supervisorctl

### DIFF
--- a/supervisor/supervisorctl.py
+++ b/supervisor/supervisorctl.py
@@ -86,7 +86,7 @@ class fgthread(threading.Thread):
     def localtrace(self, frame, why, arg):
         if self.killed:
             if why == 'line':
-                raise SystemExit()
+                raise SystemExit(1)
         return self.localtrace
 
     def kill(self):
@@ -216,9 +216,13 @@ class Controller(cmd.Cmd):
         except socket.error, why:
             if why[0] == errno.ECONNREFUSED:
                 self.output('%s refused connection' % self.options.serverurl)
+                if not self.options.interactive:
+                    raise SystemExit(4)
                 return False
             elif why[0] == errno.ENOENT:
                 self.output('%s no such file' % self.options.serverurl)
+                if not self.options.interactive:
+                    raise SystemExit(5)
                 return False
             raise
         return True

--- a/supervisor/tests/test_supervisorctl.py
+++ b/supervisor/tests/test_supervisorctl.py
@@ -60,6 +60,7 @@ class ControllerTests(unittest.TestCase):
         def raise_fault(*arg, **kw):     
             raise socket.error(errno.ECONNREFUSED, 'nobody home')
         options._server.supervisor.getVersion = raise_fault
+        options.interactive = True
 
         controller = self._makeOne(options)
         controller.stdout = StringIO()
@@ -70,6 +71,19 @@ class ControllerTests(unittest.TestCase):
         output = controller.stdout.getvalue() 
         self.assertTrue('refused connection' in output)
 
+    def test__upcheck_catches_socket_error_ECONNREFUSED_noninteractive(self):
+        options = DummyClientOptions()
+        import socket
+        import errno
+        def raise_fault(*arg, **kw):
+            raise socket.error(errno.ECONNREFUSED, 'nobody home')
+        options._server.supervisor.getVersion = raise_fault
+
+        controller = self._makeOne(options)
+        controller.stdout = StringIO()
+
+        self.assertRaises(SystemExit, controller.upcheck)
+
     def test__upcheck_catches_socket_error_ENOENT(self):
         options = DummyClientOptions()
         import socket
@@ -77,6 +91,7 @@ class ControllerTests(unittest.TestCase):
         def raise_fault(*arg, **kw):     
             raise socket.error(errno.ENOENT, 'nobody home')
         options._server.supervisor.getVersion = raise_fault
+        options.interactive = True
 
         controller = self._makeOne(options)
         controller.stdout = StringIO()
@@ -86,6 +101,19 @@ class ControllerTests(unittest.TestCase):
 
         output = controller.stdout.getvalue() 
         self.assertTrue('no such file' in output)
+
+    def test__upcheck_catches_socket_error_ENOENT_noninteractive(self):
+        options = DummyClientOptions()
+        import socket
+        import errno
+        def raise_fault(*arg, **kw):
+            raise socket.error(errno.ENOENT, 'nobody home')
+        options._server.supervisor.getVersion = raise_fault
+
+        controller = self._makeOne(options)
+        controller.stdout = StringIO()
+
+        self.assertRaises(SystemExit, controller.upcheck)
 
     def test_onecmd(self):
         options = DummyClientOptions()


### PR DESCRIPTION
This is a first pass at addressing #24 and #116, and allows regular automation of starting supervisor if it is not already running (e.g. supervisorctl status &>/dev/null || supervisord).