### PR TITLE
Print a warning if the included config doesn't contain at least one valid section

### DIFF
--- a/supervisor/tests/fixtures/conf.d/config.conf
+++ b/supervisor/tests/fixtures/conf.d/config.conf
@@ -1,0 +1,2 @@
+[progam:foo]
+command=echo "hello"

--- a/supervisor/tests/fixtures/config-include.conf
+++ b/supervisor/tests/fixtures/config-include.conf
@@ -1,0 +1,11 @@
+[supervisord]
+http_port=/tmp/donothing.sock ; (default is to run a UNIX domain socket server)
+logfile=/tmp/donothing.log ; (main log file;default $CWD/supervisord.log)
+pidfile=/tmp/donothing.pid ; (supervisord pidfile;default supervisord.pid)
+nodaemon=true              ; (start in foreground if true;default false)
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[include]
+files=conf.d/*.conf


### PR DESCRIPTION
This pull request adds support for printing a warning if the included config file doesn't contain at least one valid section.

This should make spotting issues which are related to typos a lot easier. For example, today I just spent a bunch of time debugging an issue which was related to me misspelling "program" as "progam" (yes, I do use spell checking in my text editor, but it's not so smart to recognize ":" as a delimiter).