### PR TITLE
Fix some naming issues

### DIFF
--- a/supervisor/datatypes.py
+++ b/supervisor/datatypes.py
@@ -119,9 +119,9 @@ def logfile_name(val):
 class RangeCheckedConversion:
     """Conversion helper that range checks another conversion."""
 
-    def __init__(self, conversion, min=None, max=None):
-        self._min = min
-        self._max = max
+    def __init__(self, conversion, rmin=None, rmax=None):
+        self._min = rmin
+        self._max = rmax
         self._conversion = conversion
 
     def __call__(self, value):
@@ -134,7 +134,7 @@ class RangeCheckedConversion:
                              % (repr(v), repr(self._max)))
         return v
 
-port_number = RangeCheckedConversion(integer, min=1, max=0xffff).__call__
+port_number = RangeCheckedConversion(integer, rmin=1, rmax=0xffff).__call__
 
 def inet_address(s):
     # returns (host, port) tuple

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -1286,21 +1286,21 @@ class ServerOptions(Options):
 
         for limit in limits:
 
-            min = limit['min']
+            lmin = limit['min']
             res = limit['resource']
             msg = limit['msg']
             name = limit['name']
 
             soft, hard = resource.getrlimit(res)
 
-            if (soft < min) and (soft != -1): # -1 means unlimited
-                if (hard < min) and (hard != -1):
+            if (soft < lmin) and (soft != -1): # -1 means unlimited
+                if (hard < lmin) and (hard != -1):
                     # setrlimit should increase the hard limit if we are
                     # root, if not then setrlimit raises and we print usage
-                    hard = min
+                    hard = lmin
 
                 try:
-                    resource.setrlimit(res, (min, hard))
+                    resource.setrlimit(res, (lmin, hard))
                     msgs.append('Increased %(name)s limit to %(min)s' %
                                 locals())
                 except (resource.error, ValueError):

--- a/supervisor/tests/test_datatypes.py
+++ b/supervisor/tests/test_datatypes.py
@@ -256,7 +256,7 @@ class DatatypesTest(unittest.TestCase):
         self.assertRaises(ValueError, datatypes.name_to_gid, "foo")
 
     @patch("grp.getgrgid", Mock(side_effect=KeyError("bad group id")))
-    def test_name_to_gid_raises_for_bad_group_name(self):
+    def test_name_to_gid_raises_for_bad_group_id(self):
         self.assertRaises(ValueError, datatypes.name_to_gid, "42")
 
 class InetStreamSocketConfigTests(unittest.TestCase):
@@ -404,8 +404,8 @@ class RangeCheckedConversionTests(unittest.TestCase):
         from supervisor.datatypes import RangeCheckedConversion
         return RangeCheckedConversion
 
-    def _makeOne(self, conversion, min=None, max=None):
-        return self._getTargetClass()(conversion, min, max)
+    def _makeOne(self, conversion, rmin=None, rmax=None):
+        return self._getTargetClass()(conversion, rmin, rmax)
 
     def test_below_lower_bound(self):
         conversion = self._makeOne(lambda *arg: -1, 0)


### PR DESCRIPTION
Just a proposal, Python's keyword should not be used as normal variables in
order to avoid future potential problems.

Also in the test suite, the function name is duplicated with existing one.
