### PR TITLE
add MANIFEST.in file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include supervisor/version.txt


### PR DESCRIPTION
After i use `sudo python setup.py install` to install supervisor on my OS X 10.8.5. i excute `supervisord`, but to see this:

```
Traceback (most recent call last):
  File "/usr/local/bin/supervisord", line 9, in <module>
    load_entry_point('supervisor==3.1a1-dev', 'console_scripts', 'supervisord')()
  File "/Library/Python/2.7/site-packages/distribute-0.6.49-py2.7.egg/pkg_resources.py", line 345, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/Library/Python/2.7/site-packages/distribute-0.6.49-py2.7.egg/pkg_resources.py", line 2381, in load_entry_point
    return ep.load()
  File "/Library/Python/2.7/site-packages/distribute-0.6.49-py2.7.egg/pkg_resources.py", line 2087, in load
    entry = __import__(self.module_name, globals(),globals(), ['__name__'])
  File "/Library/Python/2.7/site-packages/supervisor-3.1a1_dev-py2.7.egg/supervisor/supervisord.py", line 41, in <module>
    from supervisor.options import ServerOptions
  File "/Library/Python/2.7/site-packages/supervisor-3.1a1_dev-py2.7.egg/supervisor/options.py", line 57, in <module>
    VERSION = open(version_txt).read().strip()
IOError: [Errno 2] No such file or directory: '/Library/Python/2.7/site-packages/supervisor-3.1a1_dev-py2.7.egg/supervisor/version.txt'
```

I think this is because when installing the supervisor/version.txt file included in, so adding a [MANIFEST.in template](http://docs.python.org/2/distutils/sourcedist.html#the-manifest-in-template)
