### PR TITLE
Parse env configuration in posix mode

### DIFF
--- a/supervisor/datatypes.py
+++ b/supervisor/datatypes.py
@@ -81,7 +81,7 @@ def dict_of_key_value_pairs(arg):
     """ parse KEY=val,KEY2=val2 into {'KEY':'val', 'KEY2':'val2'}
         Quotes can be used to allow commas in the value
     """
-    lexer = shlex.shlex(arg)
+    lexer = shlex.shlex(arg, posix=True)
     lexer.wordchars += '/.+-():'
 
     tokens = list(lexer)
@@ -93,7 +93,7 @@ def dict_of_key_value_pairs(arg):
         k_eq_v = tokens[i:i+3]
         if len(k_eq_v) != 3 or k_eq_v[1] != '=':
             raise ValueError("Unexpected end of key/value pairs")
-        D[k_eq_v[0]] = k_eq_v[2].strip('\'"')
+        D[k_eq_v[0]] = k_eq_v[2]
         i += 4
     return D
 

--- a/supervisor/tests/test_datatypes.py
+++ b/supervisor/tests/test_datatypes.py
@@ -115,6 +115,21 @@ class DatatypesTest(unittest.TestCase):
         expected = {'foo': 'bar,baz', 'baz': 'q,ux'}
         self.assertEqual(actual, expected)
 
+    def test_dict_of_key_value_pairs_handles_newlines_inside_quotes(self):
+        actual = datatypes.dict_of_key_value_pairs('foo="a\nb\nc"')
+        expected = {'foo': 'a\nb\nc'}
+        self.assertEqual(actual, expected)
+
+    def test_dict_of_key_value_pairs_handles_quotes_inside_quotes(self):
+        actual = datatypes.dict_of_key_value_pairs('foo="\'\\""')
+        expected = {'foo': '\'"'}
+        self.assertEqual(actual, expected)
+
+    def test_dict_of_key_value_pairs_handles_empty_inside_quotes(self):
+        actual = datatypes.dict_of_key_value_pairs('foo=""')
+        expected = {'foo': ''}
+        self.assertEqual(actual, expected)
+
     def test_dict_of_key_value_pairs_handles_unquoted_non_alphanum(self):
         actual = datatypes.dict_of_key_value_pairs(
             'HOME=/home/auser,FOO=/.foo+(1.2)-_/,'


### PR DESCRIPTION
Fixes #328

This allows (escaped) quotes in the values as well as empty
values.
