### PR TITLE
Store raw parameters from .conf files in process/group config objects

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -628,7 +628,8 @@ class ServerOptions(Options):
                 group_processes.extend(processes)
             raw_params = dict(parser.items(section))
             groups.append(
-                ProcessGroupConfig(self, group_name, priority, group_processes, raw_params)
+                ProcessGroupConfig(self, group_name, priority, group_processes,
+                                   raw_params=raw_params)
                 )
 
         # process "normal" homogeneous groups
@@ -642,7 +643,8 @@ class ServerOptions(Options):
                                                   ProcessConfig)
             raw_params = dict(parser.items(section))
             groups.append(
-                ProcessGroupConfig(self, program_name, priority, processes, raw_params)
+                ProcessGroupConfig(self, program_name, priority, processes,
+                                   raw_params=raw_params)
                 )
 
         # process "event listener" homogeneous groups
@@ -681,7 +683,8 @@ class ServerOptions(Options):
             groups.append(
                 EventListenerPoolConfig(self, pool_name, priority, processes,
                                         buffer_size, pool_events,
-                                        result_handler, raw_params)
+                                        result_handler,
+                                        raw_params=raw_params)
                 )
 
         # process fastcgi homogeneous groups
@@ -735,7 +738,7 @@ class ServerOptions(Options):
             raw_params = dict(parser.items(section))
             groups.append(
                 FastCGIGroupConfig(self, program_name, priority, processes,
-                                   socket_config, raw_params)
+                                   socket_config, raw_params=raw_params)
                 )
 
         groups.sort()
@@ -1646,9 +1649,9 @@ class ProcessConfig(Config):
         'exitcodes', 'redirect_stderr' ]
     optional_param_names = [ 'environment', 'serverurl' ]
 
-    def __init__(self, options, raw_params, **params):
+    def __init__(self, options, raw_params=None, **params):
         self.options = options
-        self.raw_params = raw_params
+        self.raw_params = raw_params if raw_params is not None else {}
         for name in self.req_param_names:
             setattr(self, name, params[name])
         for name in self.optional_param_names:
@@ -1741,12 +1744,12 @@ class FastCGIProcessConfig(ProcessConfig):
         return dispatchers, p
 
 class ProcessGroupConfig(Config):
-    def __init__(self, options, name, priority, process_configs, raw_params):
+    def __init__(self, options, name, priority, process_configs, raw_params=None):
         self.options = options
         self.name = name
         self.priority = priority
         self.process_configs = process_configs
-        self.raw_params = raw_params
+        self.raw_params = raw_params if raw_params is not None else {}
 
     def __eq__(self, other):
         if not isinstance(other, ProcessGroupConfig):
@@ -1771,7 +1774,7 @@ class ProcessGroupConfig(Config):
 
 class EventListenerPoolConfig(Config):
     def __init__(self, options, name, priority, process_configs, buffer_size,
-                 pool_events, result_handler, raw_params):
+                 pool_events, result_handler, raw_params=None):
         self.options = options
         self.name = name
         self.priority = priority
@@ -1779,7 +1782,7 @@ class EventListenerPoolConfig(Config):
         self.buffer_size = buffer_size
         self.pool_events = pool_events
         self.result_handler = result_handler
-        self.raw_params = raw_params
+        self.raw_params = raw_params if raw_params is not None else {}
 
     def __eq__(self, other):
         if not isinstance(other, EventListenerPoolConfig):
@@ -1800,13 +1803,13 @@ class EventListenerPoolConfig(Config):
 
 class FastCGIGroupConfig(ProcessGroupConfig):
     def __init__(self, options, name, priority, process_configs,
-                 socket_config, raw_params):
+                 socket_config, raw_params=None):
         self.options = options
         self.name = name
         self.priority = priority
         self.process_configs = process_configs
         self.socket_config = socket_config
-        self.raw_params = raw_params
+        self.raw_params = raw_params if raw_params is not None else {}
 
     def __eq__(self, other):
         if not isinstance(other, FastCGIGroupConfig):

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -626,8 +626,9 @@ class ServerOptions(Options):
                                                         group_name,
                                                         ProcessConfig)
                 group_processes.extend(processes)
+            raw_params = dict(parser.items(section))
             groups.append(
-                ProcessGroupConfig(self, group_name, priority, group_processes)
+                ProcessGroupConfig(self, group_name, priority, group_processes, raw_params)
                 )
 
         # process "normal" homogeneous groups
@@ -639,8 +640,9 @@ class ServerOptions(Options):
             priority = integer(get(section, 'priority', 999))
             processes=self.processes_from_section(parser, section, program_name,
                                                   ProcessConfig)
+            raw_params = dict(parser.items(section))
             groups.append(
-                ProcessGroupConfig(self, program_name, priority, processes)
+                ProcessGroupConfig(self, program_name, priority, processes, raw_params)
                 )
 
         # process "event listener" homogeneous groups
@@ -675,11 +677,11 @@ class ServerOptions(Options):
                 pool_events.append(pool_event)
             processes=self.processes_from_section(parser, section, pool_name,
                                                   EventListenerConfig)
-
+            raw_params = dict(parser.items(section))
             groups.append(
                 EventListenerPoolConfig(self, pool_name, priority, processes,
                                         buffer_size, pool_events,
-                                        result_handler)
+                                        result_handler, raw_params)
                 )
 
         # process fastcgi homogeneous groups
@@ -730,9 +732,10 @@ class ServerOptions(Options):
 
             processes=self.processes_from_section(parser, section, program_name,
                                                   FastCGIProcessConfig)
+            raw_params = dict(parser.items(section))
             groups.append(
                 FastCGIGroupConfig(self, program_name, priority, processes,
-                                   socket_config)
+                                   socket_config, raw_params)
                 )
 
         groups.sort()
@@ -776,6 +779,7 @@ class ServerOptions(Options):
             klass = ProcessConfig
         programs = []
         get = parser.saneget
+        raw_params = dict(parser.items(section))
         program_name = process_or_group_name(section.split(':', 1)[1])
         priority = integer(get(section, 'priority', 999))
         autostart = boolean(get(section, 'autostart', 'true'))
@@ -875,6 +879,7 @@ class ServerOptions(Options):
 
             pconfig = klass(
                 self,
+                raw_params=raw_params,
                 name=expand(process_name, expansions, 'process_name'),
                 command=expand(command, expansions, 'command'),
                 directory=directory,
@@ -1641,8 +1646,9 @@ class ProcessConfig(Config):
         'exitcodes', 'redirect_stderr' ]
     optional_param_names = [ 'environment', 'serverurl' ]
 
-    def __init__(self, options, **params):
+    def __init__(self, options, raw_params, **params):
         self.options = options
+        self.raw_params = raw_params
         for name in self.req_param_names:
             setattr(self, name, params[name])
         for name in self.optional_param_names:
@@ -1735,11 +1741,12 @@ class FastCGIProcessConfig(ProcessConfig):
         return dispatchers, p
 
 class ProcessGroupConfig(Config):
-    def __init__(self, options, name, priority, process_configs):
+    def __init__(self, options, name, priority, process_configs, raw_params):
         self.options = options
         self.name = name
         self.priority = priority
         self.process_configs = process_configs
+        self.raw_params = raw_params
 
     def __eq__(self, other):
         if not isinstance(other, ProcessGroupConfig):
@@ -1764,7 +1771,7 @@ class ProcessGroupConfig(Config):
 
 class EventListenerPoolConfig(Config):
     def __init__(self, options, name, priority, process_configs, buffer_size,
-                 pool_events, result_handler):
+                 pool_events, result_handler, raw_params):
         self.options = options
         self.name = name
         self.priority = priority
@@ -1772,6 +1779,7 @@ class EventListenerPoolConfig(Config):
         self.buffer_size = buffer_size
         self.pool_events = pool_events
         self.result_handler = result_handler
+        self.raw_params = raw_params
 
     def __eq__(self, other):
         if not isinstance(other, EventListenerPoolConfig):
@@ -1792,12 +1800,13 @@ class EventListenerPoolConfig(Config):
 
 class FastCGIGroupConfig(ProcessGroupConfig):
     def __init__(self, options, name, priority, process_configs,
-                 socket_config):
+                 socket_config, raw_params):
         self.options = options
         self.name = name
         self.priority = priority
         self.process_configs = process_configs
         self.socket_config = socket_config
+        self.raw_params = raw_params
 
     def __eq__(self, other):
         if not isinstance(other, FastCGIGroupConfig):
@@ -2026,4 +2035,3 @@ class NoPermission(ProcessException):
     """ Indicates that the file cannot be executed because the supervisor
     process does not possess the appropriate UNIX filesystem permission
     to execute the file. """
-

--- a/supervisor/tests/test_options.py
+++ b/supervisor/tests/test_options.py
@@ -1606,6 +1606,7 @@ class TestProcessConfig(unittest.TestCase):
                      'redirect_stderr', 'environment'):
             defaults[name] = name
         defaults.update(kw)
+        defaults['raw_params'] = {}
         return self._getTargetClass()(*arg, **defaults)
 
     def test_create_autochildlogs(self):
@@ -1680,6 +1681,7 @@ class FastCGIProcessConfigTest(unittest.TestCase):
                      'redirect_stderr', 'environment'):
             defaults[name] = name
         defaults.update(kw)
+        defaults['raw_params'] = {}
         return self._getTargetClass()(*arg, **defaults)
 
     def test_make_process(self):
@@ -1719,28 +1721,29 @@ class ProcessGroupConfigTests(unittest.TestCase):
         from supervisor.options import ProcessGroupConfig
         return ProcessGroupConfig
 
-    def _makeOne(self, options, name, priority, pconfigs):
-        return self._getTargetClass()(options, name, priority, pconfigs)
+    def _makeOne(self, options, name, priority, pconfigs, raw_params):
+        return self._getTargetClass()(options, name, priority, pconfigs, raw_params)
 
     def test_ctor(self):
         options = DummyOptions()
-        instance = self._makeOne(options, 'whatever', 999, [])
+        instance = self._makeOne(options, 'whatever', 999, [], {'a':'b'})
         self.assertEqual(instance.options, options)
         self.assertEqual(instance.name, 'whatever')
         self.assertEqual(instance.priority, 999)
         self.assertEqual(instance.process_configs, [])
+        self.assertEqual(instance.raw_params, {'a':'b'})
 
     def test_after_setuid(self):
         options = DummyOptions()
         pconfigs = [DummyPConfig(options, 'process1', '/bin/process1')]
-        instance = self._makeOne(options, 'whatever', 999, pconfigs)
+        instance = self._makeOne(options, 'whatever', 999, pconfigs, {})
         instance.after_setuid()
         self.assertEqual(pconfigs[0].autochildlogs_created, True)
 
     def test_make_group(self):
         options = DummyOptions()
         pconfigs = [DummyPConfig(options, 'process1', '/bin/process1')]
-        instance = self._makeOne(options, 'whatever', 999, pconfigs)
+        instance = self._makeOne(options, 'whatever', 999, pconfigs, {})
         group = instance.make_group()
         from supervisor.process import ProcessGroup
         self.assertEqual(group.__class__, ProcessGroup)
@@ -1756,7 +1759,7 @@ class FastCGIGroupConfigTests(unittest.TestCase):
     def test_ctor(self):
         options = DummyOptions()
         sock_config = DummySocketConfig(6)
-        instance = self._makeOne(options, 'whatever', 999, [], sock_config)
+        instance = self._makeOne(options, 'whatever', 999, [], sock_config, {})
         self.assertEqual(instance.options, options)
         self.assertEqual(instance.name, 'whatever')
         self.assertEqual(instance.priority, 999)
@@ -1766,10 +1769,10 @@ class FastCGIGroupConfigTests(unittest.TestCase):
     def test_same_sockets_are_equal(self):
         options = DummyOptions()
         sock_config1 = DummySocketConfig(6)
-        instance1 = self._makeOne(options, 'whatever', 999, [], sock_config1)
+        instance1 = self._makeOne(options, 'whatever', 999, [], sock_config1, {})
 
         sock_config2 = DummySocketConfig(6)
-        instance2 = self._makeOne(options, 'whatever', 999, [], sock_config2)
+        instance2 = self._makeOne(options, 'whatever', 999, [], sock_config2, {})
 
         self.assertTrue(instance1 == instance2)
         self.assertFalse(instance1 != instance2)
@@ -1777,10 +1780,10 @@ class FastCGIGroupConfigTests(unittest.TestCase):
     def test_diff_sockets_are_not_equal(self):
         options = DummyOptions()
         sock_config1 = DummySocketConfig(6)
-        instance1 = self._makeOne(options, 'whatever', 999, [], sock_config1)
+        instance1 = self._makeOne(options, 'whatever', 999, [], sock_config1, {})
 
         sock_config2 = DummySocketConfig(7)
-        instance2 = self._makeOne(options, 'whatever', 999, [], sock_config2)
+        instance2 = self._makeOne(options, 'whatever', 999, [], sock_config2, {})
 
         self.assertTrue(instance1 != instance2)
         self.assertFalse(instance1 == instance2)
@@ -1837,4 +1840,3 @@ def test_suite():
 
 if __name__ == '__main__':
     unittest.main(defaultTest='test_suite')
-


### PR DESCRIPTION
Store raw parameters from the .conf file for each process/group with the config objects. This allows setting custom parameters per program/group that can be used by by plugins utilizing the rpc interface.

Example:
[program:xyz]
command=/bin/cat
custom_param1=12345
custom_foo=bar

All key/value pairs in this section would be available via this process's .config.raw_params as a dict