### PR TITLE
Append timestamp to stdout and stderr logs and config flags

### DIFF
--- a/supervisor/dispatchers.py
+++ b/supervisor/dispatchers.py
@@ -132,11 +132,17 @@ class POutputDispatcher(PDispatcher):
 
         maxbytes = getattr(config, '%s_logfile_maxbytes' % channel)
         backups = getattr(config, '%s_logfile_backups' % channel)
-        fmt = '%(message)s'
-        if logfile == 'syslog':
+        append_timestamp = getattr(config,'%s_append_timestamp' % channel)
+        if append_timestamp:
+            fmt = '%(asctime)s: %(message)s'
+        else:
+            fmt = '%(message)s'
+        
+	if logfile == 'syslog':
             warnings.warn("Specifying 'syslog' for filename is deprecated. "
                 "Use %s_syslog instead." % channel, DeprecationWarning)
             fmt = ' '.join((config.name, fmt))
+        
         self.mainlog = loggers.handle_file(
             config.options.getLogger(),
             filename=logfile,

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -923,6 +923,10 @@ class ServerOptions(Options):
                 syslog = boolean(get(section, sy_key, False))
                 logfiles[sy_key] = syslog
 
+                append_ts_key = '%s_append_timestamp' % k
+                append_ts = boolean(get(section,append_ts_key,False))
+                logfiles[append_ts_key] = append_ts
+
                 if lf_val is Automatic and not maxbytes:
                     self.parse_warnings.append(
                         'For [%s], AUTO logging used for %s without '
@@ -942,12 +946,14 @@ class ServerOptions(Options):
                 startretries=startretries,
                 uid=uid,
                 stdout_logfile=logfiles['stdout_logfile'],
+                stdout_append_timestamp=logfiles['stdout_append_timestamp'],
                 stdout_capture_maxbytes = stdout_cmaxbytes,
                 stdout_events_enabled = stdout_events,
                 stdout_logfile_backups=logfiles['stdout_logfile_backups'],
                 stdout_logfile_maxbytes=logfiles['stdout_logfile_maxbytes'],
                 stdout_syslog=logfiles['stdout_syslog'],
                 stderr_logfile=logfiles['stderr_logfile'],
+                stderr_append_timestamp=logfiles['stderr_append_timestamp'],
                 stderr_capture_maxbytes = stderr_cmaxbytes,
                 stderr_events_enabled = stderr_events,
                 stderr_logfile_backups=logfiles['stderr_logfile_backups'],
@@ -1711,7 +1717,7 @@ class ProcessConfig(Config):
         'stderr_events_enabled', 'stderr_syslog',
         'stopsignal', 'stopwaitsecs', 'stopasgroup', 'killasgroup',
         'exitcodes', 'redirect_stderr' ]
-    optional_param_names = [ 'environment', 'serverurl' ]
+    optional_param_names = [ 'environment', 'serverurl','stdout_append_timestamp','stderr_append_timestamp' ]
 
     def __init__(self, options, **params):
         self.options = options

--- a/supervisor/skel/sample.conf
+++ b/supervisor/skel/sample.conf
@@ -78,11 +78,13 @@ serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
 ;stdout_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
 ;stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
 ;stdout_capture_maxbytes=1MB   ; number of bytes in 'capturemode' (default 0)
+;stdout_append_timestamp=true  ; appends timestamp to stdout log file ( default false)
 ;stdout_events_enabled=false   ; emit events on stdout writes (default false)
 ;stderr_logfile=/a/path        ; stderr log path, NONE for none; default AUTO
 ;stderr_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
 ;stderr_logfile_backups=10     ; # of stderr logfile backups (default 10)
 ;stderr_capture_maxbytes=1MB   ; number of bytes in 'capturemode' (default 0)
+;stderr_append_timestamp=true  ; appends timestamp to stderr log file (default false)
 ;stderr_events_enabled=false   ; emit events on stderr writes (default false)
 ;environment=A="1",B="2"       ; process environment additions (def no adds)
 ;serverurl=AUTO                ; override serverurl computation (childutils)

--- a/supervisor/tests/base.py
+++ b/supervisor/tests/base.py
@@ -509,7 +509,7 @@ class DummyPConfig:
                  stdout_events_enabled=False,
                  stdout_logfile_backups=0, stdout_logfile_maxbytes=0,
                  stderr_logfile=None, stderr_capture_maxbytes=0,
-                 stderr_events_enabled=False,
+                 stderr_events_enabled=False,stdout_append_timestamp=False,stderr_append_timestamp=False,
                  stderr_logfile_backups=0, stderr_logfile_maxbytes=0,
                  redirect_stderr=False,
                  stopsignal=None, stopwaitsecs=10, stopasgroup=False, killasgroup=False,
@@ -534,6 +534,8 @@ class DummyPConfig:
         self.stderr_logfile_backups = stderr_logfile_backups
         self.stderr_logfile_maxbytes = stderr_logfile_maxbytes
         self.redirect_stderr = redirect_stderr
+        self.stdout_append_timestamp = stdout_append_timestamp
+        self.stderr_append_timestamp = stderr_append_timestamp
         if stopsignal is None:
             import signal
             stopsignal = signal.SIGTERM

--- a/supervisor/tests/test_options.py
+++ b/supervisor/tests/test_options.py
@@ -543,6 +543,7 @@ class ServerOptionsTests(unittest.TestCase):
         self.assertEqual(proc1.startretries, 10)
         self.assertEqual(proc1.uid, 0)
         self.assertEqual(proc1.stdout_logfile, '/tmp/cat.log')
+        self.assertEqual(proc1.stdout_append_timestamp,False)
         self.assertEqual(proc1.stopsignal, signal.SIGKILL)
         self.assertEqual(proc1.stopwaitsecs, 5)
         self.assertEqual(proc1.stopasgroup, False)


### PR DESCRIPTION
Append timestamp to stdout and stderr logs and config flagsthis uses 'asctime' internal - dict value to append timestamp to stdout , stderr logs.

%s_append_timestamp enables/disables this feature per process.