### PR TITLE
Update pidproxy.py to accept SIGQUIT and pass to children.

### DIFF
--- a/supervisor/pidproxy.py
+++ b/supervisor/pidproxy.py
@@ -40,6 +40,7 @@ class PidProxy:
         signal.signal(signal.SIGINT, self.passtochild)
         signal.signal(signal.SIGUSR1, self.passtochild)
         signal.signal(signal.SIGUSR2, self.passtochild)
+        signal.signal(signal.SIGQUIT, self.passtochild)
         signal.signal(signal.SIGCHLD, self.reap)
 
     def reap(self, sig, frame):


### PR DESCRIPTION
Looks like pidproxy is not handling SIGQUIT signals. This simply adds support for this signal.
