### PR TITLE
Warn about empty globbing of `include.files`

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -544,7 +544,12 @@ class ServerOptions(Options):
                 base = '.'
             for pattern in files:
                 pattern = os.path.join(base, pattern)
-                for filename in glob.glob(pattern):
+                filenames = glob.glob(pattern)
+                if not filenames:
+                    self.parse_warnings.append(
+                        'No file matches via include "%s"' % pattern)
+                    continue
+                for filename in filenames:
                     self.parse_warnings.append(
                         'Included extra file "%s" during parsing' % filename)
                     try:


### PR DESCRIPTION
Fixes #345
