### PR TITLE
Add `parse_infos` to options, use it for "parsed file" message

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -432,6 +432,7 @@ class ServerOptions(Options):
         self.pidhistory = {}
         self.process_group_configs = []
         self.parse_warnings = []
+        self.parse_infos = []
         self.signal_receiver = SignalReceiver()
 
     def version(self, dummy):
@@ -517,6 +518,7 @@ class ServerOptions(Options):
         # Clear parse warnings, since we may be re-reading the
         # config a second time after a reload.
         self.parse_warnings = []
+        self.parse_infos = []
 
         section = self.configroot.supervisord
         if not hasattr(fp, 'read'):
@@ -545,7 +547,7 @@ class ServerOptions(Options):
             for pattern in files:
                 pattern = os.path.join(base, pattern)
                 for filename in glob.glob(pattern):
-                    self.parse_warnings.append(
+                    self.parse_infos.append(
                         'Included extra file "%s" during parsing' % filename)
                     try:
                         parser.read(filename)

--- a/supervisor/supervisord.py
+++ b/supervisor/supervisord.py
@@ -69,6 +69,7 @@ class Supervisor:
         if self.options.first:
             rlimit_messages = self.options.set_rlimits()
             info_messages.extend(rlimit_messages)
+        info_messages.extend(self.options.parse_infos)
         warn_messages.extend(self.options.parse_warnings)
 
         # this sets the options.logger object

--- a/supervisor/tests/base.py
+++ b/supervisor/tests/base.py
@@ -65,6 +65,7 @@ class DummyOptions:
         self.openreturn = None
         self.readfd_result = ''
         self.parse_warnings = []
+        self.parse_infos = []
         self.serverurl = 'http://localhost:9001'
         self.changed_directory = False
         self.chdir_error = None


### PR DESCRIPTION
This adds a new parse_infos besides parse_warnings, and uses it for the
'Included extra file "%s" during parsing' info.

Fixes #272