### PR TITLE
Allow process-level rlimits

### DIFF
--- a/supervisor/process.py
+++ b/supervisor/process.py
@@ -288,6 +288,26 @@ class Subprocess:
             # supervisord from being sent to children.
             options.setpgrp()
 
+            # update rlimits
+            limit_fds = None
+            limit_procs = None
+            limit_memlock = None
+            if hasattr(self.config, 'limit_fds'):
+                limit_fds = self.config.limit_fds
+            if hasattr(self.config, 'limit_procs'):
+                limit_procs = self.config.limit_procs
+            if hasattr(self.config, 'limit_memlock'):
+                limit_memlock = self.config.limit_memlock
+            try:
+                for message in options.set_rlimits(
+                        enforce_max=True,
+                        limit_fds=limit_fds,
+                        limit_procs=limit_procs,
+                        limit_memlock=limit_memlock):
+                    options.logger.info(message)
+            except ValueError, e:
+                options.write(2, "Error when setting rlimits: %s\n" % str(e))
+
             self._prepare_child_fds()
             # sending to fd 2 will put this output in the stderr log
 

--- a/supervisor/supervisord.py
+++ b/supervisor/supervisord.py
@@ -67,8 +67,11 @@ class Supervisor:
         if setuid_msg:
             critical_messages.append(setuid_msg)
         if self.options.first:
-            rlimit_messages = self.options.set_rlimits()
-            info_messages.extend(rlimit_messages)
+            try:
+                rlimit_messages = self.options.set_rlimits()
+                info_messages.extend(rlimit_messages)
+            except ValueError, err:
+                options.usage(str(err))
         warn_messages.extend(self.options.parse_warnings)
 
         # this sets the options.logger object

--- a/supervisor/tests/base.py
+++ b/supervisor/tests/base.py
@@ -86,9 +86,14 @@ class DummyOptions:
     def cleanup_fds(self):
         self.fds_cleaned_up = True
 
-    def set_rlimits(self):
-        self.rlimits_set = True
-        return ['rlimits_set']
+    def set_rlimits(self, enforce_max=False, limit_fds=None, limit_procs=None,
+                    limit_memlock=None):
+        self.rlimits_set = {'enforce_max': enforce_max,
+                            'limit_fds':   limit_fds,
+                            'limit_procs': limit_procs,
+                            'limit_memlock': limit_memlock}
+        return ['rlimits_set enforce_max=%s limit_fds=%s limit_procs=%s limit_memlock=%s'
+                % (enforce_max, limit_fds, limit_procs, limit_memlock)]
 
     def set_uid(self):
         self.setuid_called = True
@@ -491,7 +496,8 @@ class DummyPConfig:
                  stderr_logfile_backups=0, stderr_logfile_maxbytes=0,
                  redirect_stderr=False,
                  stopsignal=None, stopwaitsecs=10, stopasgroup=False, killasgroup=False,
-                 exitcodes=(0,2), environment=None, serverurl=None):
+                 exitcodes=(0,2), environment=None, serverurl=None,
+                 limit_fds=None, limit_procs=None, limit_memlock=None):
         self.options = options
         self.name = name
         self.command = command
@@ -521,6 +527,9 @@ class DummyPConfig:
         self.killasgroup = killasgroup
         self.exitcodes = exitcodes
         self.environment = environment
+        self.limit_fds = limit_fds
+        self.limit_procs = limit_procs
+        self.limit_memlock = limit_memlock
         self.directory = directory
         self.umask = umask
         self.autochildlogs_created = False

--- a/supervisor/tests/test_process.py
+++ b/supervisor/tests/test_process.py
@@ -940,6 +940,23 @@ class SubprocessTests(unittest.TestCase):
         self.assertEqual(options.privsdropped, 1)
         self.assertEqual(msg, None)
 
+    def test_rlimits(self):
+        limit_fds = 5042
+        limit_procs = 4042
+        limit_memlock = 70042
+        expected = {'enforce_max':   True,
+                    'limit_fds':     limit_fds,
+                    'limit_procs':   limit_procs,
+                    'limit_memlock': limit_memlock}
+        options = DummyOptions()
+        config = DummyPConfig(options, 'test', '/test',
+                              limit_fds=limit_fds,
+                              limit_procs=limit_procs,
+                              limit_memlock=limit_memlock)
+        instance = self._makeOne(config)
+        instance.spawn()
+        self.assertEquals(expected, options.rlimits_set)
+
     def test_cmp_bypriority(self):
         options = DummyOptions()
         config = DummyPConfig(options, 'notthere', '/notthere',

--- a/supervisor/tests/test_supervisord.py
+++ b/supervisor/tests/test_supervisord.py
@@ -81,9 +81,10 @@ class SupervisordTests(unittest.TestCase):
         supervisord.main()
         self.assertEqual(options.environment_processed, True)
         self.assertEqual(options.fds_cleaned_up, False)
-        self.assertEqual(options.rlimits_set, True)
+        self.assertTrue(options.rlimits_set)
         self.assertEqual(options.make_logger_messages,
-                         (['setuid_called'], [], ['rlimits_set']))
+                         (['setuid_called'], [],
+                          ['rlimits_set enforce_max=False limit_fds=None limit_procs=None limit_memlock=None']))
         self.assertEqual(options.autochildlogdir_cleared, True)
         self.assertEqual(len(supervisord.process_groups), 1)
         self.assertEqual(supervisord.process_groups['foo'].config.options,


### PR DESCRIPTION
Supervisor only supports rlimits for supervisor itself. This adds
the ability to add limit_fds, limit_procs, and limit_memlock to the
supervised process' conf file.

Tested that the three options take effect on rhel6.
