### PR TITLE
Fix the link to the GitHub repo in the documentation.

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -23,7 +23,7 @@ Version Control Repository
 --------------------------
 
 You can also view the `Supervisor version control repository
-<https://github.com/supervisor/supervisor>`_.
+<https://github.com/Supervisor/supervisor>`_.
 
 Contributing
 ------------


### PR DESCRIPTION
GitHub's user and organization names are case-sensitive, so we must use
"Supervisor" rather than "supervisor".
