### PR TITLE
environment_file configuration directive

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -791,6 +791,7 @@ class ServerOptions(Options):
         numprocs = integer(get(section, 'numprocs', 1))
         numprocs_start = integer(get(section, 'numprocs_start', 0))
         environment_str = get(section, 'environment', '')
+        environment_file = get(section, 'environment_file', None)
         stdout_cmaxbytes = byte_size(get(section,'stdout_capture_maxbytes','0'))
         stdout_events = boolean(get(section, 'stdout_events_enabled','false'))
         stderr_cmaxbytes = byte_size(get(section,'stderr_capture_maxbytes','0'))
@@ -838,6 +839,12 @@ class ServerOptions(Options):
                           'group_name':group_name}
             expansions.update(environ_expansions())
 
+            if environment_file:
+                try:
+                    env_fd = open(environment_file)
+                except IOError as e:
+                    raise ValueError("Unable to open environment_file={}".format(environment_file))
+                environment_str += ','.join(env_fd.read().strip().split("\n"))
             environment = dict_of_key_value_pairs(
                 expand(environment_str, expansions, 'environment'))
 

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -831,6 +831,12 @@ class ServerOptions(Options):
             raise ValueError("Cannot set stopasgroup=true and killasgroup=false")
 
         host_node_name = platform.node()
+        if environment_file:
+            try:
+                env_fd = open(environment_file)
+            except IOError as e:
+                raise ValueError("Unable to open environment_file={}".format(environment_file))
+            environment_str += ','.join(env_fd.read().strip().split("\n"))
         for process_num in range(numprocs_start, numprocs + numprocs_start):
             expansions = {'here':self.here,
                           'process_num':process_num,
@@ -839,12 +845,6 @@ class ServerOptions(Options):
                           'group_name':group_name}
             expansions.update(environ_expansions())
 
-            if environment_file:
-                try:
-                    env_fd = open(environment_file)
-                except IOError as e:
-                    raise ValueError("Unable to open environment_file={}".format(environment_file))
-                environment_str += ','.join(env_fd.read().strip().split("\n"))
             environment = dict_of_key_value_pairs(
                 expand(environment_str, expansions, 'environment'))
 

--- a/supervisor/tests/fixtures/test_env
+++ b/supervisor/tests/fixtures/test_env
@@ -1,0 +1,2 @@
+TEST_ENV_VAR_0=something
+TEST_ENV_VAR_1="something else"

--- a/supervisor/tests/test_options.py
+++ b/supervisor/tests/test_options.py
@@ -317,7 +317,7 @@ class ServerOptionsTests(unittest.TestCase):
         priority=6
         process_name = cat6
         command = /bin/cat
-        environment_file = tests/fixtures/test_env
+        environment_file = supervisor/tests/fixtures/test_env
         """ % {'tempdir':tempfile.gettempdir()})
 
         from supervisor import datatypes

--- a/supervisor/tests/test_options.py
+++ b/supervisor/tests/test_options.py
@@ -317,7 +317,7 @@ class ServerOptionsTests(unittest.TestCase):
         priority=6
         process_name = cat6
         command = /bin/cat
-        environment_file = fixtures/test_env
+        environment_file = tests/fixtures/test_env
         """ % {'tempdir':tempfile.gettempdir()})
 
         from supervisor import datatypes

--- a/supervisor/tests/test_options.py
+++ b/supervisor/tests/test_options.py
@@ -312,6 +312,12 @@ class ServerOptionsTests(unittest.TestCase):
         numprocs_start = 1
         command = /bin/cat
         directory = /some/path/foo_%%(process_num)02d
+
+        [program:cat6]
+        priority=6
+        process_name = cat6
+        command = /bin/cat
+        environment_file = fixtures/test_env
         """ % {'tempdir':tempfile.gettempdir()})
 
         from supervisor import datatypes
@@ -342,7 +348,7 @@ class ServerOptionsTests(unittest.TestCase):
         self.assertEqual(options.minfds, 2048)
         self.assertEqual(options.minprocs, 300)
         self.assertEqual(options.nocleanup, True)
-        self.assertEqual(len(options.process_group_configs), 5)
+        self.assertEqual(len(options.process_group_configs), 6)
         self.assertEqual(options.environment, dict(FAKE_ENV_VAR='/some/path'))
 
         cat1 = options.process_group_configs[0]
@@ -493,6 +499,16 @@ class ServerOptionsTests(unittest.TestCase):
         self.assertEqual(instance.nocleanup, True)
         self.assertEqual(instance.minfds, 2048)
         self.assertEqual(instance.minprocs, 300)
+
+        cat6 = options.process_group_configs[5]
+        self.assertEqual(cat6.name, 'cat6')
+        self.assertEqual(cat6.priority, 6)
+        self.assertEqual(len(cat6.process_configs), 1)
+
+        proc6 = cat6.process_configs[0]
+        self.assertEqual(proc6.name, 'cat6')
+        self.assertEqual(proc6.environment['TEST_ENV_VAR_0'], 'something')
+        self.assertEqual(proc6.environment['TEST_ENV_VAR_1'], 'something else')
 
     def test_no_config_file_exits(self):
         instance = self._makeOne()


### PR DESCRIPTION
Due to the fact that we need to have a lot of variables per process
controlled by their respective environment files, we added a new
configuration directive to better facilitate such needs.