### PR TITLE
Corrected the documentation for getProcessInfo()

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -247,8 +247,8 @@ Process Control
 
         .. describe:: stop
 
-            UNIX timestamp of when the process ended, or 0 if the process is
-            still running.
+            UNIX timestamp of when the process last ended, or 0 if the process
+            has never been stopped.
 
         .. describe:: now
 


### PR DESCRIPTION
The value for `stop` is only 0 when the process has never been stopped. If the process has been restarted and is now running, the value will be the last time the process restarted.
