### PR TITLE
.gitignore: Add std{out,err}_logfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ build/
 docs/.build/
 dist/
 .tox/
+stdout_logfile
+stderr_logfile
 nosetests.xml
 supervisor/coverage.xml
 tmp/


### PR DESCRIPTION
Just add 2 files to `.gitignore` that get created by the tests.

```
$ ls -l stderr_logfile stdout_logfile
ls: stderr_logfile: No such file or directory
ls: stdout_logfile: No such file or directory

$ tox -e py26
...
  py26: commands succeeded
  congratulations :)

$ ls -l stderr_logfile stdout_logfile
-rw-r--r--  1 marca  staff  0 Feb 21 17:43 stderr_logfile
-rw-r--r--  1 marca  staff  0 Feb 21 17:43 stdout_logfile
```
