### PR TITLE
TestProcessConfig.tearDown: Cleanup std{err,out}_logfile files if they exist

### DIFF
--- a/supervisor/tests/test_options.py
+++ b/supervisor/tests/test_options.py
@@ -1608,6 +1608,11 @@ class TestProcessConfig(unittest.TestCase):
         defaults.update(kw)
         return self._getTargetClass()(*arg, **defaults)
 
+    def tearDown(self):
+        for fn in ('stdout_logfile', 'stderr_logfile'):
+            if os.path.exists(fn):
+                os.remove(fn)
+
     def test_create_autochildlogs(self):
         options = DummyOptions()
         instance = self._makeOne(options)


### PR DESCRIPTION
This appears to fix the problem of these files being left around after test runs, alluded to in https://github.com/Supervisor/supervisor/pull/377#issuecomment-35792044
