### PR TITLE
Prevent DummyLogger from creating files

### DIFF
--- a/supervisor/loggers.py
+++ b/supervisor/loggers.py
@@ -344,6 +344,9 @@ def handle_syslog(logger, fmt):
     logger.addHandler(handler)
 
 def handle_file(logger, filename, fmt, rotating=False, maxbytes=0, backups=0):
+    if 'Dummy' in logger.__class__.__name__:
+        return logger
+
     if filename == 'syslog':
         handler = SyslogHandler()
 


### PR DESCRIPTION
Here's an alternative solution to prevent the tests from creating `stdout_logfile` and `stderr_logfile` files (the issue discussed in #377).

The key is to detect the `DummyLogger` (I don't like checking the class name but couldn't figure out quite how to do it with duck typing without breaking anything) and to not create any handlers that create files.
