### PR TITLE
this adds support for status output for groups

### DIFF
--- a/supervisor/rpcinterface.py
+++ b/supervisor/rpcinterface.py
@@ -502,6 +502,8 @@ class SupervisorNamespaceRPCInterface:
         self._update('getProcessInfo')
 
         group, process = self._getGroupAndProcess(name)
+        if process is None:
+            return self._getGroupProcessInfo(group)
 
         if process is None:
             raise RPCError(Faults.BAD_NAME, name)
@@ -547,6 +549,17 @@ class SupervisorNamespaceRPCInterface:
 
         output = []
         for group, process in all_processes:
+            name = make_namespec(group.config.name, process.config.name)
+            output.append(self.getProcessInfo(name))
+        return output
+
+    def _getGroupProcessInfo(self, group):
+        """ Get info about the processes of a certain group
+
+        @return array result  An array of process status results
+        """
+        output = []
+        for process in group.processes.values():
             name = make_namespec(group.config.name, process.config.name)
             output.append(self.getProcessInfo(name))
         return output

--- a/supervisor/supervisorctl.py
+++ b/supervisor/supervisorctl.py
@@ -578,7 +578,10 @@ class DefaultControllerPlugin(ControllerPluginBase):
                     else:
                         raise
                     continue
-                self.ctl.output(self._procrepr(info))
+                if not isinstance(info, list):
+                    info = [info]
+                for i in info:
+                    self.ctl.output(self._procrepr(i))
         else:
             for info in supervisor.getAllProcessInfo():
                 self.ctl.output(self._procrepr(info))


### PR DESCRIPTION
I took @simonjj's change in PR #135 and pulled out just the one commit that is needed for this feature, as he had one extra commit, probably because he did the change and the PR from his `master` branch.

I figured a cleaner PR would be preferable and easier to review.

```
(profilesvc)vagrant@ubuntu:/opt/webapp/profilesvc/src/supervisor$ python ./supervisor/supervisorctl.py status profilesvc:*
profilesvc:9601                  RUNNING    pid 8688, uptime 0:01:33
profilesvc:9600                  RUNNING    pid 8689, uptime 0:01:33
profilesvc:9603                  RUNNING    pid 8690, uptime 0:01:32
profilesvc:9602                  RUNNING    pid 8691, uptime 0:01:31
profilesvc:9604                  RUNNING    pid 8692, uptime 0:01:30
```

Thanks to @simonjj, for authoring this change!
