### PR TITLE
from __future__ import absolute_import

### DIFF
--- a/supervisor/compat.py
+++ b/supervisor/compat.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import sys
 PY3 = sys.version>'3'
 if PY3:


### PR DESCRIPTION
Fixes clash between stdlib `http` and `supervisor/http.py`

Fixes GH-386.
