### PR TITLE
tox.ini: Use nosetests and {posargs}

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,10 +9,11 @@ envlist =
 
 [testenv]
 commands =
-    python setup.py test -q
+    nosetests {posargs}
 deps =
     https://github.com/Supervisor/meld3/tarball/master
     mock >= 0.5.0
+    nose
 usedevelop = true
 
 [testenv:py33]


### PR DESCRIPTION
- `{posargs}` allows passing arguments or tests on the tox command-line -- e.g.:

``` bash
    tox -e py33 -- --verbose --pdb-failures supervisor.tests.test_options
```
- Get rid of warnings about unclosed files; hopefully limited to the
  tests though perhaps we should check this; note to display these with
  nosetests, set `PYTHONWARNINGS="d"`:

``` bash
    PYTHONWARNINGS="d" tox -e py33
```

Warnings look like:

```
/Users/marca/dev/git-repos/supervisor/supervisor/dispatchers.py:300: ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/foo' mode='a' encoding='UTF-8'>
  backups=backups,
/Users/marca/dev/git-repos/supervisor/supervisor/dispatchers.py:147: ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/foo' mode='a' encoding='UTF-8'>
  backups=backups)
/Library/Frameworks/Python.framework/Versions/3.3/lib/python3.3/unittest/case.py:384: ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/log' mode='a' encoding='UTF-8'>
  function()
```

Here's drilling down into one of them:

```
$ PYTHONWARNINGS="d" tox -e py33 -- -q supervisor.tests.test_options:TestProcessConfig.test_make_dispatchers_stderr_not_redirected
py33 develop-inst-nodeps: /Users/marca/dev/git-repos/supervisor
py33 runtests: commands[0] | nosetests -q supervisor.tests.test_options:TestProcessConfig.test_make_dispatchers_stderr_not_redirected
/Users/marca/dev/git-repos/supervisor/supervisor/dispatchers.py:147: ResourceWarning: unclosed file <_io.TextIOWrapper name='stdout_logfile' mode='a' encoding='UTF-8'>
  backups=backups)
/Users/marca/dev/git-repos/supervisor/supervisor/dispatchers.py:147: ResourceWarning: unclosed file <_io.TextIOWrapper name='stderr_logfile' mode='a' encoding='UTF-8'>
  backups=backups)
----------------------------------------------------------------------
Ran 1 test in 0.001s
```
