### PR TITLE
[feature.py3] supervisor/http.py: Allow request and file gc

### DIFF
--- a/supervisor/http.py
+++ b/supervisor/http.py
@@ -5,6 +5,7 @@ import sys
 import supervisor.medusa.text_socket as socket
 import errno
 import pwd
+import weakref
 
 from supervisor.compat import urllib
 from supervisor.compat import sha1
@@ -640,13 +641,17 @@ class supervisor_af_unix_http_server(supervisor_http_server):
 class tail_f_producer:
     def __init__(self, request, filename, head):
         self.file = open(filename, 'rb')
-        self.request = request
+        self.request = weakref.ref(request)
         self.delay = 0.1
         sz = self.fsize()
         if sz >= head:
             self.sz = sz - head
         else:
             self.sz = 0
+
+    def __del__(self):
+        if self.file:
+            self.file.close()
 
     def more(self):
         try:


### PR DESCRIPTION
Make `tail_f_producer` have weakref to request.
Add `tail_f_producer.__del__` that closes file.

This eliminates 3 `ResourceWarning` warnings mentioned in #391.
### without:

```
$ PYTHONWARNINGS="d" .tox/py33/bin/nosetests -q 2>&1 | grep -c ResourceWarning
13
```
### with:

```
$ PYTHONWARNINGS="d" .tox/py33/bin/nosetests -q 2>&1 | grep -c ResourceWarning
10
```

Cc: @mcdonc, @mnaberez 
