### PR TITLE
Add RotatingFileHandler.__del__ that closes stream

### DIFF
--- a/supervisor/loggers.py
+++ b/supervisor/loggers.py
@@ -184,6 +184,13 @@ class RotatingFileHandler(FileHandler):
         self.counter = 0
         self.every = 10
 
+    def __del__(self):
+        if self.stream:
+            try:
+                self.stream.close()
+            except OSError as exc:
+                pass
+
     def emit(self, record):
         """
         Emit a record.


### PR DESCRIPTION
Eliminates 5 of the `ResourceWarning` warnings mentioned in GH-391.
### Without:

```
$ PYTHONWARNINGS="d" .tox/py33/bin/nosetests -q 2>&1 | grep -c ResourceWarning
13
```
### With:

```
$ PYTHONWARNINGS="d" .tox/py33/bin/nosetests -q 2>&1 | grep -c ResourceWarning
8
```

Cc: @mcdonc, @mnaberez 
