### PR TITLE
[feature.py3] Fix 2 unclosed sockets that can happen on errors in supervisor/datatypes.py

### DIFF
--- a/supervisor/datatypes.py
+++ b/supervisor/datatypes.py
@@ -212,8 +212,12 @@ class InetStreamSocketConfig(SocketConfig):
 
     def create_and_bind(self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        sock.bind(self.addr())
+        try:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.bind(self.addr())
+        except:
+            sock.close()
+            raise
         return sock
 
 class UnixStreamSocketConfig(SocketConfig):
@@ -237,13 +241,14 @@ class UnixStreamSocketConfig(SocketConfig):
         if os.path.exists(self.path):
             os.unlink(self.path)
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        sock.bind(self.addr())
         try:
+            sock.bind(self.addr())
             self._chown()
             self._chmod()
         except:
             sock.close()
-            os.unlink(self.path)
+            if os.path.exists(self.path):
+                os.unlink(self.path)
             raise
         return sock
 


### PR DESCRIPTION
Makes sure that socket gets closed in that the case that we create it but then an exception is raised while calling `bind` or other operations on it.

Fixes 2 of the `ResourceWarning` warnings in GH-391.

```
$ PYTHONWARNINGS="d" .tox/py33/bin/nosetests -q supervisor.tests.test_socket_manager
/Library/Frameworks/Python.framework/Versions/3.3/lib/python3.3/unittest/case.py:135: ResourceWarning: unclosed <supervisor.medusa.text_socket.text_socket object, fd=4, family=2, type=1, proto=0>
  callable_obj(*args, **kwargs)
/Library/Frameworks/Python.framework/Versions/3.3/lib/python3.3/unittest/case.py:135: ResourceWarning: unclosed <supervisor.medusa.text_socket.text_socket object, fd=3, family=1, type=1, proto=0>
  callable_obj(*args, **kwargs)
----------------------------------------------------------------------
Ran 13 tests in 0.181s

OK

$ git checkout feature.py3.fix_two_unclosed_sockets_on_errors
Switched to branch 'feature.py3.fix_two_unclosed_sockets_on_errors'

$ PYTHONWARNINGS="d" .tox/py33/bin/nosetests -q supervisor.tests.test_socket_manager
----------------------------------------------------------------------
Ran 13 tests in 0.011s

OK
```

Cc: @mcdonc, @mnaberez 
