### PR TITLE
tox.ini: Remove py25

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 envlist =
-    py25,py26,py27
+    py26,py27
 
 [testenv]
 commands =


### PR DESCRIPTION
Python 2.5 is old and tox and virtualenv don't support it anymore
