### PR TITLE
make an assert_no_leaks decorator that does stuff with lsof

### DIFF
--- a/supervisor/tests/test_http.py
+++ b/supervisor/tests/test_http.py
@@ -16,6 +16,7 @@ from supervisor.tests.base import DummyRPCInterfaceFactory
 from supervisor.tests.base import DummyPConfig
 from supervisor.tests.base import DummyOptions
 from supervisor.tests.base import DummyRequest
+from supervisor.tests.utils import assert_no_leaks
 
 from supervisor.http import NOT_DONE_YET
 
@@ -24,12 +25,13 @@ class HandlerTests:
         return self._getTargetClass()(supervisord)
 
     def test_match(self):
-        class DummyRequest:
-            def __init__(self, uri):
-                self.uri = uri
-        supervisor = DummySupervisor()
-        handler = self._makeOne(supervisor)
-        self.assertEqual(handler.match(DummyRequest(handler.path)), True)
+        with assert_no_leaks():
+            class DummyRequest:
+                def __init__(self, uri):
+                    self.uri = uri
+            supervisor = DummySupervisor()
+            handler = self._makeOne(supervisor)
+            self.assertEqual(handler.match(DummyRequest(handler.path)), True)
 
 class LogtailHandlerTests(HandlerTests, unittest.TestCase):
     def _getTargetClass(self):
@@ -37,45 +39,48 @@ class LogtailHandlerTests(HandlerTests, unittest.TestCase):
         return logtail_handler
 
     def test_handle_request_stdout_logfile_none(self):
-        options = DummyOptions()
-        pconfig = DummyPConfig(options, 'process1', '/bin/process1', priority=1,
-                               stdout_logfile='/tmp/process1.log')
-        supervisord = PopulatedDummySupervisor(options, 'process1', pconfig)
-        handler = self._makeOne(supervisord)
-        request = DummyRequest('/logtail/process1', None, None, None)
-        handler.handle_request(request)
-        self.assertEqual(request._error, 410)
+        with assert_no_leaks():
+            options = DummyOptions()
+            pconfig = DummyPConfig(options, 'process1', '/bin/process1', priority=1,
+                                   stdout_logfile='/tmp/process1.log')
+            supervisord = PopulatedDummySupervisor(options, 'process1', pconfig)
+            handler = self._makeOne(supervisord)
+            request = DummyRequest('/logtail/process1', None, None, None)
+            handler.handle_request(request)
+            self.assertEqual(request._error, 410)
 
     def test_handle_request_stdout_logfile_missing(self):
-        supervisor = DummySupervisor()
-        options = DummyOptions()
-        pconfig = DummyPConfig(options, 'foo', 'foo', 'it/is/missing')
-        supervisord = PopulatedDummySupervisor(options, 'foo', pconfig)
-        handler = self._makeOne(supervisord)
-        request = DummyRequest('/logtail/foo', None, None, None)
-        handler.handle_request(request)
-        self.assertEqual(request._error, 410)
+        with assert_no_leaks():
+            supervisor = DummySupervisor()
+            options = DummyOptions()
+            pconfig = DummyPConfig(options, 'foo', 'foo', 'it/is/missing')
+            supervisord = PopulatedDummySupervisor(options, 'foo', pconfig)
+            handler = self._makeOne(supervisord)
+            request = DummyRequest('/logtail/foo', None, None, None)
+            handler.handle_request(request)
+            self.assertEqual(request._error, 410)
 
     def test_handle_request(self):
-        supervisor = DummySupervisor()
-        import tempfile
-        import os
-        import stat
-        f = tempfile.NamedTemporaryFile()
-        t = f.name
-        options = DummyOptions()
-        pconfig = DummyPConfig(options, 'foo', 'foo', stdout_logfile=t)
-        supervisord = PopulatedDummySupervisor(options, 'foo', pconfig)
-        handler = self._makeOne(supervisord)
-        request = DummyRequest('/logtail/foo', None, None, None)
-        handler.handle_request(request)
-        self.assertEqual(request._error, None)
-        from supervisor.medusa import http_date
-        self.assertEqual(request.headers['Last-Modified'],
-                         http_date.build_http_date(os.stat(t)[stat.ST_MTIME]))
-        self.assertEqual(request.headers['Content-Type'], 'text/plain')
-        self.assertEqual(len(request.producers), 1)
-        self.assertEqual(request._done, True)
+        with assert_no_leaks():
+            supervisor = DummySupervisor()
+            import tempfile
+            import os
+            import stat
+            f = tempfile.NamedTemporaryFile()
+            t = f.name
+            options = DummyOptions()
+            pconfig = DummyPConfig(options, 'foo', 'foo', stdout_logfile=t)
+            supervisord = PopulatedDummySupervisor(options, 'foo', pconfig)
+            handler = self._makeOne(supervisord)
+            request = DummyRequest('/logtail/foo', None, None, None)
+            handler.handle_request(request)
+            self.assertEqual(request._error, None)
+            from supervisor.medusa import http_date
+            self.assertEqual(request.headers['Last-Modified'],
+                             http_date.build_http_date(os.stat(t)[stat.ST_MTIME]))
+            self.assertEqual(request.headers['Content-Type'], 'text/plain')
+            self.assertEqual(len(request.producers), 1)
+            self.assertEqual(request._done, True)
 
 class MainLogTailHandlerTests(HandlerTests, unittest.TestCase):
     def _getTargetClass(self):
@@ -83,38 +88,41 @@ class MainLogTailHandlerTests(HandlerTests, unittest.TestCase):
         return mainlogtail_handler
 
     def test_handle_request_stdout_logfile_none(self):
-        supervisor = DummySupervisor()
-        handler = self._makeOne(supervisor)
-        request = DummyRequest('/mainlogtail', None, None, None)
-        handler.handle_request(request)
-        self.assertEqual(request._error, 410)
+        with assert_no_leaks():
+            supervisor = DummySupervisor()
+            handler = self._makeOne(supervisor)
+            request = DummyRequest('/mainlogtail', None, None, None)
+            handler.handle_request(request)
+            self.assertEqual(request._error, 410)
 
     def test_handle_request_stdout_logfile_missing(self):
-        supervisor = DummySupervisor()
-        supervisor.options.logfile = '/not/there'
-        request = DummyRequest('/mainlogtail', None, None, None)
-        handler = self._makeOne(supervisor)
-        handler.handle_request(request)
-        self.assertEqual(request._error, 410)
+        with assert_no_leaks():
+            supervisor = DummySupervisor()
+            supervisor.options.logfile = '/not/there'
+            request = DummyRequest('/mainlogtail', None, None, None)
+            handler = self._makeOne(supervisor)
+            handler.handle_request(request)
+            self.assertEqual(request._error, 410)
 
     def test_handle_request(self):
-        supervisor = DummySupervisor()
-        import tempfile
-        import os
-        import stat
-        f = tempfile.NamedTemporaryFile()
-        t = f.name
-        supervisor.options.logfile = t
-        handler = self._makeOne(supervisor)
-        request = DummyRequest('/mainlogtail', None, None, None)
-        handler.handle_request(request)
-        self.assertEqual(request._error, None)
-        from supervisor.medusa import http_date
-        self.assertEqual(request.headers['Last-Modified'],
-                         http_date.build_http_date(os.stat(t)[stat.ST_MTIME]))
-        self.assertEqual(request.headers['Content-Type'], 'text/plain')
-        self.assertEqual(len(request.producers), 1)
-        self.assertEqual(request._done, True)
+        with assert_no_leaks():
+            supervisor = DummySupervisor()
+            import tempfile
+            import os
+            import stat
+            f = tempfile.NamedTemporaryFile()
+            t = f.name
+            supervisor.options.logfile = t
+            handler = self._makeOne(supervisor)
+            request = DummyRequest('/mainlogtail', None, None, None)
+            handler.handle_request(request)
+            self.assertEqual(request._error, None)
+            from supervisor.medusa import http_date
+            self.assertEqual(request.headers['Last-Modified'],
+                             http_date.build_http_date(os.stat(t)[stat.ST_MTIME]))
+            self.assertEqual(request.headers['Content-Type'], 'text/plain')
+            self.assertEqual(len(request.producers), 1)
+            self.assertEqual(request._done, True)
 
 
 class TailFProducerTests(unittest.TestCase):
@@ -126,26 +134,27 @@ class TailFProducerTests(unittest.TestCase):
         return self._getTargetClass()(request, filename, head)
 
     def test_handle_more(self):
-        request = DummyRequest('/logtail/foo', None, None, None)
-        import tempfile
-        from supervisor import http
-        f = tempfile.NamedTemporaryFile()
-        f.write('a' * 80)
-        f.flush()
-        t = f.name
-        producer = self._makeOne(request, t, 80)
-        result = producer.more()
-        self.assertEqual(result, 'a' * 80)
-        f.write('w' * 100)
-        f.flush()
-        result = producer.more()
-        self.assertEqual(result, 'w' * 100)
-        result = producer.more()
-        self.assertEqual(result, http.NOT_DONE_YET)
-        f.truncate(0)
-        f.flush()
-        result = producer.more()
-        self.assertEqual(result, '==> File truncated <==\n')
+        with assert_no_leaks():
+            request = DummyRequest('/logtail/foo', None, None, None)
+            import tempfile
+            from supervisor import http
+            f = tempfile.NamedTemporaryFile()
+            f.write('a' * 80)
+            f.flush()
+            t = f.name
+            producer = self._makeOne(request, t, 80)
+            result = producer.more()
+            self.assertEqual(result, 'a' * 80)
+            f.write('w' * 100)
+            f.flush()
+            result = producer.more()
+            self.assertEqual(result, 'w' * 100)
+            result = producer.more()
+            self.assertEqual(result, http.NOT_DONE_YET)
+            f.truncate(0)
+            f.flush()
+            result = producer.more()
+            self.assertEqual(result, '==> File truncated <==\n')
 
 class DeferringChunkedProducerTests(unittest.TestCase):
     def _getTargetClass(self):
@@ -156,19 +165,22 @@ class DeferringChunkedProducerTests(unittest.TestCase):
         return self._getTargetClass()(producer, footers)
 
     def test_more_not_done_yet(self):
-        wrapped = DummyProducer(NOT_DONE_YET)
-        producer = self._makeOne(wrapped)
-        self.assertEqual(producer.more(), NOT_DONE_YET)
+        with assert_no_leaks():
+            wrapped = DummyProducer(NOT_DONE_YET)
+            producer = self._makeOne(wrapped)
+            self.assertEqual(producer.more(), NOT_DONE_YET)
 
     def test_more_string(self):
-        wrapped = DummyProducer('hello')
-        producer = self._makeOne(wrapped)
-        self.assertEqual(producer.more(), '5\r\nhello\r\n')
+        with assert_no_leaks():
+            wrapped = DummyProducer('hello')
+            producer = self._makeOne(wrapped)
+            self.assertEqual(producer.more(), '5\r\nhello\r\n')
 
     def test_more_nodata(self):
-        wrapped = DummyProducer()
-        producer = self._makeOne(wrapped, footers=['a', 'b'])
-        self.assertEqual(producer.more(), '0\r\na\r\nb\r\n\r\n')
+        with assert_no_leaks():
+            wrapped = DummyProducer()
+            producer = self._makeOne(wrapped, footers=['a', 'b'])
+            self.assertEqual(producer.more(), '0\r\na\r\nb\r\n\r\n')
 
 class DeferringCompositeProducerTests(unittest.TestCase):
     def _getTargetClass(self):
@@ -179,22 +191,25 @@ class DeferringCompositeProducerTests(unittest.TestCase):
         return self._getTargetClass()(producers)
 
     def test_more_not_done_yet(self):
-        wrapped = DummyProducer(NOT_DONE_YET)
-        producer = self._makeOne([wrapped])
-        self.assertEqual(producer.more(), NOT_DONE_YET)
+        with assert_no_leaks():
+            wrapped = DummyProducer(NOT_DONE_YET)
+            producer = self._makeOne([wrapped])
+            self.assertEqual(producer.more(), NOT_DONE_YET)
 
     def test_more_string(self):
-        wrapped1 = DummyProducer('hello')
-        wrapped2 = DummyProducer('goodbye')
-        producer = self._makeOne([wrapped1, wrapped2])
-        self.assertEqual(producer.more(), 'hello')
-        self.assertEqual(producer.more(), 'goodbye')
-        self.assertEqual(producer.more(), '')
+        with assert_no_leaks():
+            wrapped1 = DummyProducer('hello')
+            wrapped2 = DummyProducer('goodbye')
+            producer = self._makeOne([wrapped1, wrapped2])
+            self.assertEqual(producer.more(), 'hello')
+            self.assertEqual(producer.more(), 'goodbye')
+            self.assertEqual(producer.more(), '')
 
     def test_more_nodata(self):
-        wrapped = DummyProducer()
-        producer = self._makeOne([wrapped])
-        self.assertEqual(producer.more(), '')
+        with assert_no_leaks():
+            wrapped = DummyProducer()
+            producer = self._makeOne([wrapped])
+            self.assertEqual(producer.more(), '')
 
 class DeferringGlobbingProducerTests(unittest.TestCase):
     def _getTargetClass(self):
@@ -205,23 +220,26 @@ class DeferringGlobbingProducerTests(unittest.TestCase):
         return self._getTargetClass()(producer, buffer_size)
 
     def test_more_not_done_yet(self):
-        wrapped = DummyProducer(NOT_DONE_YET)
-        producer = self._makeOne(wrapped)
-        self.assertEqual(producer.more(), NOT_DONE_YET)
+        with assert_no_leaks():
+            wrapped = DummyProducer(NOT_DONE_YET)
+            producer = self._makeOne(wrapped)
+            self.assertEqual(producer.more(), NOT_DONE_YET)
 
     def test_more_string(self):
-        wrapped = DummyProducer('hello', 'there', 'guy')
-        producer = self._makeOne(wrapped, buffer_size=1)
-        self.assertEqual(producer.more(), 'hello')
+        with assert_no_leaks():
+            wrapped = DummyProducer('hello', 'there', 'guy')
+            producer = self._makeOne(wrapped, buffer_size=1)
+            self.assertEqual(producer.more(), 'hello')
 
-        wrapped = DummyProducer('hello', 'there', 'guy')
-        producer = self._makeOne(wrapped, buffer_size=50)
-        self.assertEqual(producer.more(), 'hellothereguy')
+            wrapped = DummyProducer('hello', 'there', 'guy')
+            producer = self._makeOne(wrapped, buffer_size=50)
+            self.assertEqual(producer.more(), 'hellothereguy')
 
     def test_more_nodata(self):
-        wrapped = DummyProducer()
-        producer = self._makeOne(wrapped)
-        self.assertEqual(producer.more(), '')
+        with assert_no_leaks():
+            wrapped = DummyProducer()
+            producer = self._makeOne(wrapped)
+            self.assertEqual(producer.more(), '')
 
 class DeferringHookedProducerTests(unittest.TestCase):
     def _getTargetClass(self):
@@ -232,29 +250,32 @@ class DeferringHookedProducerTests(unittest.TestCase):
         return self._getTargetClass()(producer, function)
 
     def test_more_not_done_yet(self):
-        wrapped = DummyProducer(NOT_DONE_YET)
-        producer = self._makeOne(wrapped, None)
-        self.assertEqual(producer.more(), NOT_DONE_YET)
+        with assert_no_leaks():
+            wrapped = DummyProducer(NOT_DONE_YET)
+            producer = self._makeOne(wrapped, None)
+            self.assertEqual(producer.more(), NOT_DONE_YET)
 
     def test_more_string(self):
-        wrapped = DummyProducer('hello')
-        L = []
-        def callback(bytes):
-            L.append(bytes)
-        producer = self._makeOne(wrapped, callback)
-        self.assertEqual(producer.more(), 'hello')
-        self.assertEqual(L, [])
-        producer.more()
-        self.assertEqual(L, [5])
+        with assert_no_leaks():
+            wrapped = DummyProducer('hello')
+            L = []
+            def callback(bytes):
+                L.append(bytes)
+            producer = self._makeOne(wrapped, callback)
+            self.assertEqual(producer.more(), 'hello')
+            self.assertEqual(L, [])
+            producer.more()
+            self.assertEqual(L, [5])
 
     def test_more_nodata(self):
-        wrapped = DummyProducer()
-        L = []
-        def callback(bytes):
-            L.append(bytes)
-        producer = self._makeOne(wrapped, callback)
-        self.assertEqual(producer.more(), '')
-        self.assertEqual(L, [0])
+        with assert_no_leaks():
+            wrapped = DummyProducer()
+            L = []
+            def callback(bytes):
+                L.append(bytes)
+            producer = self._makeOne(wrapped, callback)
+            self.assertEqual(producer.more(), '')
+            self.assertEqual(L, [0])
 
 class EncryptedDictionaryAuthorizedTests(unittest.TestCase):
     def _getTargetClass(self):
@@ -265,30 +286,36 @@ class EncryptedDictionaryAuthorizedTests(unittest.TestCase):
         return self._getTargetClass()(dict)
 
     def test_authorize_baduser(self):
-        authorizer = self._makeOne({})
-        self.assertFalse(authorizer.authorize(('foo', 'bar')))
+        with assert_no_leaks():
+            authorizer = self._makeOne({})
+            self.assertFalse(authorizer.authorize(('foo', 'bar')))
 
     def test_authorize_gooduser_badpassword(self):
-        authorizer = self._makeOne({'foo':'password'})
-        self.assertFalse(authorizer.authorize(('foo', 'bar')))
+        with assert_no_leaks():
+            authorizer = self._makeOne({'foo':'password'})
+            self.assertFalse(authorizer.authorize(('foo', 'bar')))
 
     def test_authorize_gooduser_goodpassword(self):
-        authorizer = self._makeOne({'foo':'password'})
-        self.assertTrue(authorizer.authorize(('foo', 'password')))
+        with assert_no_leaks():
+            authorizer = self._makeOne({'foo':'password'})
+            self.assertTrue(authorizer.authorize(('foo', 'password')))
 
     def test_authorize_gooduser_goodpassword_with_colon(self):
-        authorizer = self._makeOne({'foo':'pass:word'})
-        self.assertTrue(authorizer.authorize(('foo', 'pass:word')))
+        with assert_no_leaks():
+            authorizer = self._makeOne({'foo':'pass:word'})
+            self.assertTrue(authorizer.authorize(('foo', 'pass:word')))
 
     def test_authorize_gooduser_badpassword_sha(self):
-        password = '{SHA}' + sha1('password').hexdigest()
-        authorizer = self._makeOne({'foo':password})
-        self.assertFalse(authorizer.authorize(('foo', 'bar')))
+        with assert_no_leaks():
+            password = '{SHA}' + sha1('password').hexdigest()
+            authorizer = self._makeOne({'foo':password})
+            self.assertFalse(authorizer.authorize(('foo', 'bar')))
 
     def test_authorize_gooduser_goodpassword_sha(self):
-        password = '{SHA}' + sha1('password').hexdigest()
-        authorizer = self._makeOne({'foo':password})
-        self.assertTrue(authorizer.authorize(('foo', 'password')))
+        with assert_no_leaks():
+            password = '{SHA}' + sha1('password').hexdigest()
+            authorizer = self._makeOne({'foo':password})
+            self.assertTrue(authorizer.authorize(('foo', 'password')))
 
 class SupervisorAuthHandlerTests(unittest.TestCase):
     def _getTargetClass(self):
@@ -299,37 +326,41 @@ class SupervisorAuthHandlerTests(unittest.TestCase):
         return self._getTargetClass()(dict, handler)
 
     def test_ctor(self):
-        handler = self._makeOne({'a':1}, None)
-        from supervisor.http import encrypted_dictionary_authorizer
-        self.assertEqual(handler.authorizer.__class__,
-                         encrypted_dictionary_authorizer)
+        with assert_no_leaks():
+            handler = self._makeOne({'a':1}, None)
+            from supervisor.http import encrypted_dictionary_authorizer
+            self.assertEqual(handler.authorizer.__class__,
+                             encrypted_dictionary_authorizer)
 
     def test_handle_request_authorizes_good_credentials(self):
-        request = DummyRequest('/logtail/process1', None, None, None)
-        encoded = base64.b64encode("user:password")
-        request.header = ["Authorization: Basic %s" % encoded]
-        handler = DummyHandler()
-        auth_handler = self._makeOne({'user':'password'}, handler)
-        auth_handler.handle_request(request)
-        self.assertTrue(handler.handled_request)
+        with assert_no_leaks():
+            request = DummyRequest('/logtail/process1', None, None, None)
+            encoded = base64.b64encode("user:password")
+            request.header = ["Authorization: Basic %s" % encoded]
+            handler = DummyHandler()
+            auth_handler = self._makeOne({'user':'password'}, handler)
+            auth_handler.handle_request(request)
+            self.assertTrue(handler.handled_request)
 
     def test_handle_request_authorizes_good_password_with_colon(self):
-        request = DummyRequest('/logtail/process1', None, None, None)
-        encoded = base64.b64encode("user:pass:word") # password contains colon
-        request.header = ["Authorization: Basic %s" % encoded]
-        handler = DummyHandler()
-        auth_handler = self._makeOne({'user':'pass:word'}, handler)
-        auth_handler.handle_request(request)
-        self.assertTrue(handler.handled_request)
+        with assert_no_leaks():
+            request = DummyRequest('/logtail/process1', None, None, None)
+            encoded = base64.b64encode("user:pass:word") # password contains colon
+            request.header = ["Authorization: Basic %s" % encoded]
+            handler = DummyHandler()
+            auth_handler = self._makeOne({'user':'pass:word'}, handler)
+            auth_handler.handle_request(request)
+            self.assertTrue(handler.handled_request)
 
     def test_handle_request_does_not_authorize_bad_credentials(self):
-        request = DummyRequest('/logtail/process1', None, None, None)
-        encoded = base64.b64encode("wrong:wrong")
-        request.header = ["Authorization: Basic %s" % encoded]
-        handler = DummyHandler()
-        auth_handler = self._makeOne({'user':'password'}, handler)
-        auth_handler.handle_request(request)
-        self.assertFalse(handler.handled_request)
+        with assert_no_leaks():
+            request = DummyRequest('/logtail/process1', None, None, None)
+            encoded = base64.b64encode("wrong:wrong")
+            request.header = ["Authorization: Basic %s" % encoded]
+            handler = DummyHandler()
+            auth_handler = self._makeOne({'user':'password'}, handler)
+            auth_handler.handle_request(request)
+            self.assertFalse(handler.handled_request)
 
 
 class TopLevelFunctionTests(unittest.TestCase):
@@ -352,47 +383,49 @@ class TopLevelFunctionTests(unittest.TestCase):
         return servers
 
     def test_make_http_servers_noauth(self):
-        socketfile = tempfile.mktemp()
-        inet = {'family':socket.AF_INET, 'host':'localhost', 'port':17735,
-                'username':None, 'password':None, 'section':'inet_http_server'}
-        unix = {'family':socket.AF_UNIX, 'file':socketfile, 'chmod':0700,
-                'chown':(-1, -1), 'username':None, 'password':None,
-                'section':'unix_http_server'}
-        servers = self._make_http_servers([inet, unix])
-        self.assertEqual(len(servers), 2)
+        with assert_no_leaks():
+            socketfile = tempfile.mktemp()
+            inet = {'family':socket.AF_INET, 'host':'localhost', 'port':17735,
+                    'username':None, 'password':None, 'section':'inet_http_server'}
+            unix = {'family':socket.AF_UNIX, 'file':socketfile, 'chmod':0700,
+                    'chown':(-1, -1), 'username':None, 'password':None,
+                    'section':'unix_http_server'}
+            servers = self._make_http_servers([inet, unix])
+            self.assertEqual(len(servers), 2)
 
-        inetdata = servers[0]
-        self.assertEqual(inetdata[0], inet)
-        server = inetdata[1]
-        idents = [
-            'Supervisor XML-RPC Handler',
-            'Logtail HTTP Request Handler',
-            'Main Logtail HTTP Request Handler',
-            'Supervisor Web UI HTTP Request Handler',
-            'Default HTTP Request Handler'
-            ]
-        self.assertEqual([x.IDENT for x in server.handlers], idents)
+            inetdata = servers[0]
+            self.assertEqual(inetdata[0], inet)
+            server = inetdata[1]
+            idents = [
+                'Supervisor XML-RPC Handler',
+                'Logtail HTTP Request Handler',
+                'Main Logtail HTTP Request Handler',
+                'Supervisor Web UI HTTP Request Handler',
+                'Default HTTP Request Handler'
+                ]
+            self.assertEqual([x.IDENT for x in server.handlers], idents)
 
-        unixdata = servers[1]
-        self.assertEqual(unixdata[0], unix)
-        server = unixdata[1]
-        self.assertEqual([x.IDENT for x in server.handlers], idents)
+            unixdata = servers[1]
+            self.assertEqual(unixdata[0], unix)
+            server = unixdata[1]
+            self.assertEqual([x.IDENT for x in server.handlers], idents)
 
     def test_make_http_servers_withauth(self):
-        socketfile = tempfile.mktemp()
-        inet = {'family':socket.AF_INET, 'host':'localhost', 'port':17736,
-                'username':'username', 'password':'password',
-                'section':'inet_http_server'}
-        unix = {'family':socket.AF_UNIX, 'file':socketfile, 'chmod':0700,
-                'chown':(-1, -1), 'username':'username', 'password':'password',
-                'section':'unix_http_server'}
-        servers = self._make_http_servers([inet, unix])
-        self.assertEqual(len(servers), 2)
-        from supervisor.http import supervisor_auth_handler
-        for config, server in servers:
-            for handler in server.handlers:
-                self.assertTrue(isinstance(handler, supervisor_auth_handler),
-                                handler)
+        with assert_no_leaks():
+            socketfile = tempfile.mktemp()
+            inet = {'family':socket.AF_INET, 'host':'localhost', 'port':17736,
+                    'username':'username', 'password':'password',
+                    'section':'inet_http_server'}
+            unix = {'family':socket.AF_UNIX, 'file':socketfile, 'chmod':0700,
+                    'chown':(-1, -1), 'username':'username', 'password':'password',
+                    'section':'unix_http_server'}
+            servers = self._make_http_servers([inet, unix])
+            self.assertEqual(len(servers), 2)
+            from supervisor.http import supervisor_auth_handler
+            for config, server in servers:
+                for handler in server.handlers:
+                    self.assertTrue(isinstance(handler, supervisor_auth_handler),
+                                    handler)
 
 class DummyHandler:
     def __init__(self):

--- a/supervisor/tests/utils.py
+++ b/supervisor/tests/utils.py
@@ -1,0 +1,26 @@
+import contextlib
+import inspect
+import os
+import subprocess
+import sys
+
+
+@contextlib.contextmanager
+def assert_no_leaks():
+    def get_lsof_lines():
+        lsof_output = subprocess.Popen(
+            'lsof -p %d' % os.getpid(),
+            shell=True,
+            stdout=subprocess.PIPE).communicate()[0]
+        lines = [line for line in lsof_output.splitlines() if '/tmp' in line]
+        return set(lines)
+
+    lsof_lines_before = get_lsof_lines()
+    yield
+    lsof_lines_after = get_lsof_lines()
+
+    if len(lsof_lines_after) > len(lsof_lines_before):
+        func = inspect.stack()[2][3]
+        sys.stderr.write("*** assert_no_leaks: leaks found in %s:\n" % func)
+        for line in lsof_lines_after - lsof_lines_before:
+            sys.stderr.write("    %s\n" % line.decode('ascii'))


### PR DESCRIPTION
I'm not happy with how many lines I had to touch to do this, so this might not be ready for merge, but maybe  this will inspire some ideas about how to do it better.

You saw that I had a bunch of PRs to the `py3k` branch to fix various leaks that cause `ResourceWarning` messages in Python 3. I was wondering if we also have these leaks on master. Unfortunately, Python 2 doesn't emit the `ResourceWarning` so I wanted to have some kind of check for leaks. I messed around with a nose plugin called "drippy" but couldn't get it to detect these leaks. I eventually found this way to detect temp file leaks using `lsof`. 

I implemented it as a context manager. I would've preferred to use a decorator so we could just slap it on each function and not have to indent a bunch of lines of code, but alas the decorator wouldn't detect the problems. It seems that somehow the resources get closed before the decorator can detect them. Maybe I did something wrong though. Or maybe this could be made into a nose plugin. I thought I'd post what I have before getting too deep into this, in case you already know of some tool that does this or something.

Anyway, this shows that there are indeed leaks on the `master` branch too:

```
 ❯ .tox/py26/bin/nosetests supervisor.tests.test_http
nose.plugins.cover: ERROR: Coverage not available: unable to import coverage module
..................*** assert_no_leaks: leaks found in test_handle_request:
    python2.6 45174 marca    3u   REG                1,2         0 23404501 /private/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/tmpRojLaZ
    python2.6 45174 marca    4r   REG                1,2         0 23404501 /private/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/tmpRojLaZ
....*** assert_no_leaks: leaks found in test_handle_request:
    python2.6 45174 marca    3u   REG                1,2         0 23404503 /private/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/tmpRZ2R5b
    python2.6 45174 marca    5r   REG                1,2         0 23404503 /private/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/tmpRZ2R5b
........*** assert_no_leaks: leaks found in test_handle_more:
    python2.6 45174 marca    6r   REG                1,2         0 23404504 /private/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/tmpTbXedk
    python2.6 45174 marca    3u   REG                1,2         0 23404504 /private/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/tmpTbXedk
....
----------------------------------------------------------------------
Ran 34 tests in 1.684s

OK
```
