### PR TITLE
Add group:* to completions list for groups

### DIFF
--- a/supervisor/supervisorctl.py
+++ b/supervisor/supervisorctl.py
@@ -279,6 +279,8 @@ class Controller(cmd.Cmd):
         for info in self._get_complete_info():
             if ':' in text or info['name'] != info['group']:
                 processes.append('%s:%s' % (info['group'], info['name']))
+                if '%s:*' % info['group'] not in processes:
+                    processes.append('%s:*' % info['group'])
             else:
                 processes.append(info['name'])
         return [ p + ' ' for p in processes if p.startswith(text) ]
@@ -1162,6 +1164,7 @@ def main(args=None, options=None):
             delims = readline.get_completer_delims()
             delims = delims.replace(':', '') # "group:process" as one word
             delims = delims.replace('-', '') # names with "-" as one word
+            delims = delims.replace('*', '') # "group:process" as one word
             readline.set_completer_delims(delims)
 
             if options.history_file:

--- a/supervisor/tests/test_supervisorctl.py
+++ b/supervisor/tests/test_supervisorctl.py
@@ -193,7 +193,7 @@ class ControllerTests(unittest.TestCase):
         result = controller.complete('', 2, line='start ')
         self.assertEqual(result, 'baz:baz_01 ')
         result = controller.complete('', 3, line='start ')
-        self.assertEqual(result, None)
+        self.assertEqual(result, 'baz:* ')
 
     def test_complete_start_no_colon(self):
         options = DummyClientOptions()
@@ -213,7 +213,7 @@ class ControllerTests(unittest.TestCase):
         result = controller.complete('foo:', 0, line='start foo:')
         self.assertEqual(result, 'foo:foo ')
         result = controller.complete('foo:', 1, line='start foo:')
-        self.assertEqual(result, None)
+        self.assertEqual(result, 'foo:* ')
 
     def test_complete_start_uncompletable(self):
         options = DummyClientOptions()


### PR DESCRIPTION
This adds support for the asterisk in completions.

E.g.:

```
$ python supervisor/supervisorctl.py
cat:0                            RUNNING    pid 73067, uptime 4:34:42
cat:1                            RUNNING    pid 73066, uptime 4:34:42
cat:2                            RUNNING    pid 73069, uptime 4:34:42
cat:3                            RUNNING    pid 73068, uptime 4:34:42
cat:4                            RUNNING    pid 73070, uptime 4:34:42
supervisor> status ca
cat:*   cat:0   cat:1   cat:2   cat:3   cat:4
supervisor> status ca:<Tab>
cat:*   cat:0   cat:1   cat:2   cat:3   cat:4
supervisor> status cat:
supervisor> status cat:*<Tab>
supervisor> status cat:* 
```
