### PR TITLE
Use fancycompleter for completions

### DIFF
--- a/supervisor/supervisorctl.py
+++ b/supervisor/supervisorctl.py
@@ -23,6 +23,7 @@ actions.
 """
 
 import cmd
+import os
 import sys
 import getpass
 import xmlrpclib
@@ -30,6 +31,20 @@ import socket
 import errno
 import urlparse
 import threading
+
+fancycompleter = None
+readline = None
+
+try:
+    import fancycompleter
+except ImportError:
+    pass
+
+if os.environ.get('SUPERVISORCTL_NO_FANCYCOMPLETER'):
+    fancycompleter = None
+
+if not fancycompleter:
+    import readline
 
 from supervisor.medusa import asyncore_25 as asyncore
 
@@ -111,6 +126,12 @@ class Controller(cmd.Cmd):
                     self.vocab.append(a[3:])
             self.options.plugins.append(plugin)
             plugin.name = name
+        if fancycompleter:
+            self.completer = fancycompleter.setup()
+            self.completer.config.readline.set_completer(self.complete)
+            self.readline = self.completer.config.readline
+        else:
+            self.readline = readline
 
     def emptyline(self):
         # We don't want a blank line to repeat the last command.
@@ -232,7 +253,7 @@ class Controller(cmd.Cmd):
         state is an integer (0..n).  Each call returns a string with a new
         completion.  When no more are available, None is returned."""
         if line is None: # line is only set in tests
-            import readline
+            readline = self.readline
             line = readline.get_line_buffer()
 
         # take the last phrase from a line like "stop foo; start bar"
@@ -1172,7 +1193,7 @@ def main(args=None, options=None):
         c.onecmd(" ".join(options.args))
     if options.interactive:
         try:
-            import readline
+            readline = c.readline
             delims = readline.get_completer_delims()
             delims = delims.replace(':', '') # "group:process" as one word
             delims = delims.replace('*', '') # "group:*" as one word

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ commands =
 deps =
     mock >= 0.5.0
     meld3 >= 0.6.5
+    fancycompleter >= 0.4
 usedevelop = true
 
 [testenv:cover]


### PR DESCRIPTION
This allows using [fancycompleter](https://pypi.python.org/pypi/fancycompleter) as the completion mechanism, which offers a few nice features, the most noticeable being that it keeps the completions on the screen and filters them down as you type more characters. The main selling point of fancycompleter is color, but I haven't made any use of that yet. I played around a bit with trying to color the group namess green and the individual services purple, but it was buggy so I took it out. Perhaps more useful coloring for supervisorctl is to show stopped services in red and running services as green.

It's possible to turn off fancycompleter by setting an environment variable `SUPERVISORCTL_NO_FANCYCOMPLETER` -- this will make it use the regular readline completer.
