### PR TITLE
Fix pidproxy termination signals behavior

### DIFF
--- a/supervisor/pidproxy.py
+++ b/supervisor/pidproxy.py
@@ -13,7 +13,14 @@ class PidProxy:
     def __init__(self, args):
         self.setsignals()
         try:
-            self.pidfile, cmdargs = args[1], args[2:]
+            if args[1] == '-w':
+                grace, self.pidfile, cmdargs = args[2], args[3], args[4:]
+                self.grace_time = int(grace)
+                if self.grace_time < 0:
+                    self.grace_time = 0
+            else:
+                self.pidfile, cmdargs = args[1], args[2:]
+                self.grace_time = 0
             self.command = os.path.abspath(cmdargs[0])
             self.cmdargs = cmdargs
         except (ValueError, IndexError):
@@ -32,7 +39,8 @@ class PidProxy:
                 break
 
     def usage(self):
-        print("pidproxy.py <pidfile name> <command> [<cmdarg1> ...]")
+        print("pidproxy.py [-w <grace seconds>] <pidfile name> <command> "
+              "[<cmdarg1> ...]")
 
     def setsignals(self):
         signal.signal(signal.SIGTERM, self.passtochild)
@@ -54,6 +62,20 @@ class PidProxy:
             print("Can't read child pidfile %s!" % self.pidfile)
             return
         os.kill(pid, sig)
+        if (sig in [signal.SIGTERM, signal.SIGINT, signal.SIGQUIT] and
+                self.grace_time):
+            # Because be have a grace time, wait before sending
+            # kill signal to child
+            time.sleep(self.grace_time)
+            try:
+                r_pid, _ = os.waitpid(-1, os.WNOHANG)
+                if r_pid == 0:
+                    # the child is still alive ...
+                    os.kill(pid, signal.SIGKILL)
+            except OSError:
+                # TODO: Find out what to do when this happens
+                pass
+            sys.exit(0)
 
 def main():
     pp = PidProxy(sys.argv)


### PR DESCRIPTION
Fix pidproxy problem when receiving a SIGTERM, SIGINT or SIGQUIT, instead of only after relaying the signal it to its child process and terminate, it should wait for the child process termination. This is to avoid supervisor reporting the child process (the one we are interested) in being reported as STOPPED when it is false
