### PR TITLE
Fix Event Listener Notification in case of >1 event notifier

### DIFF
--- a/supervisor/process.py
+++ b/supervisor/process.py
@@ -793,6 +793,7 @@ class EventListenerPool(ProcessGroupBase):
             self.event_buffer.append(event)
 
     def _dispatchEvent(self, event):
+        return_value = True
         pool_serial = event.pool_serials[self.config.name]
 
         for process in self.processes.values():
@@ -809,6 +810,7 @@ class EventListenerPool(ProcessGroupBase):
                 except OSError, why:
                     if why.args[0] != errno.EPIPE:
                         raise
+                    return_value = False
                     continue
 
                 process.listener_state = EventListenerStates.BUSY
@@ -816,9 +818,8 @@ class EventListenerPool(ProcessGroupBase):
                 self.config.options.logger.debug(
                     'event %s sent to listener %s' % (
                     event.serial, process.config.name))
-                return True
 
-        return False
+        return return_value
 
     def _eventEnvelope(self, event_type, serial, pool_serial, payload):
         event_name = events.getEventNameByType(event_type)


### PR DESCRIPTION
When using eventNotifier with >1 process, Current behavior is to notify only 1 process. This is due to a return statement erroneously placed inside the for loop which iterates over all processes.

The fix is to pull out that return statement and replace a variable to hold the return value. The semantics is to return true iff all process are successfully sent notifications. If 1+ process has issues return is false.
