### PR TITLE
Added standard Debian location for Supervisor configuration file

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -101,7 +101,8 @@ class Options:
         searchpaths = [os.path.join(here, 'etc', 'supervisord.conf'),
                        os.path.join(here, 'supervisord.conf'),
                        'supervisord.conf', 'etc/supervisord.conf',
-                       '/etc/supervisord.conf']
+                       '/etc/supervisord.conf',
+                       '/etc/supervisor/supervisord.conf']
         self.searchpaths = searchpaths
 
     def default_configfile(self):
@@ -305,7 +306,7 @@ class Options:
 
     def process_config(self, do_usage=True):
         """Process configuration data structure.
-        
+
         This includes reading config file if necessary, setting defaults etc.
         """
         if self.configfile:
@@ -811,7 +812,7 @@ class ServerOptions(Options):
                 raise ValueError(
                     '%(process_num) must be present within process_name when '
                     'numprocs > 1')
-                    
+
         if stopasgroup and not killasgroup:
             raise ValueError("Cannot set stopasgroup=true and killasgroup=false")
 
@@ -1183,7 +1184,7 @@ class ServerOptions(Options):
 
             # always put our primary gid first in this list, otherwise we can
             # lose group info since sometimes the first group in the setgroups
-            # list gets overwritten on the subsequent setgid call (at least on 
+            # list gets overwritten on the subsequent setgid call (at least on
             # freebsd 9 with python 2.7 - this will be safe though for all unix
             # /python version combos)
             groups.insert(0, gid)


### PR DESCRIPTION
Debian and Ubuntu packages both place the supervisord.conf file at the following location:
```
 /etc/supervisor/supervisord.conf
```
As an enhancement, could Supervisor attempt to find that conf file in the searchpaths list setting in Options?
