### PR TITLE
Make tests not create std{out,err}_logfile in cwd

### DIFF
--- a/supervisor/tests/test_options.py
+++ b/supervisor/tests/test_options.py
@@ -1636,6 +1636,8 @@ class TestProcessConfig(unittest.TestCase):
     def test_make_dispatchers_stderr_not_redirected(self):
         options = DummyOptions()
         instance = self._makeOne(options)
+        instance.stdout_logfile = tempfile.mktemp(prefix='stdout_logfile_')
+        instance.stderr_logfile = tempfile.mktemp(prefix='stderr_logfile_')
         instance.redirect_stderr = False
         process1 = DummyProcess(instance)
         dispatchers, pipes = instance.make_dispatchers(process1)
@@ -1653,6 +1655,7 @@ class TestProcessConfig(unittest.TestCase):
     def test_make_dispatchers_stderr_redirected(self):
         options = DummyOptions()
         instance = self._makeOne(options)
+        instance.stdout_logfile = tempfile.mktemp(prefix='stdout_logfile_')
         process1 = DummyProcess(instance)
         dispatchers, pipes = instance.make_dispatchers(process1)
         self.assertEqual(dispatchers[5].channel, 'stdout')
@@ -1697,6 +1700,8 @@ class FastCGIProcessConfigTest(unittest.TestCase):
     def test_make_dispatchers(self):
         options = DummyOptions()
         instance = self._makeOne(options)
+        instance.stdout_logfile = tempfile.mktemp(prefix='stdout_logfile_')
+        instance.stderr_logfile = tempfile.mktemp(prefix='stderr_logfile_')
         instance.redirect_stderr = False
         process1 = DummyProcess(instance)
         dispatchers, pipes = instance.make_dispatchers(process1)


### PR DESCRIPTION
by modifying 3 tests to set `instance.std{out,err}_logfile` to a filename in the temp directory by using `tempfile.mktemp`

This is an alternative solution to the issue mentioned in #382 and #377.
### Before:

```
$ /bin/rm std*_logfile
$ ls -l std*_logfile
zsh: no matches found: std*_logfile
$ tox -e py26
...
$ ls -l std*_logfile
-rw-r--r--  1 marca  staff     0B Apr 14 08:29 stderr_logfile
-rw-r--r--  1 marca  staff     0B Apr 14 08:29 stdout_logfile
```
### After:

```
$ /bin/rm std*_logfile
$ ls -l std*_logfile
zsh: no matches found: std*_logfile
$ tox -e py26
...
$ ls -l std*_logfile
zsh: no matches found: std*_logfile
```

Cc: @mnaberez, @mcdonc, @gcarothers, @graffic
