### PR TITLE
Make tests not create std{out,err}_logfile in cwd

### DIFF
--- a/supervisor/tests/test_options.py
+++ b/supervisor/tests/test_options.py
@@ -1,5 +1,6 @@
 """Test suite for supervisor.options"""
 
+import logging
 import os
 import sys
 import tempfile
@@ -24,6 +25,12 @@ from supervisor.tests.base import DummyPConfig
 from supervisor.tests.base import DummyProcess
 from supervisor.tests.base import DummySocketConfig
 from supervisor.tests.base import lstrip
+
+def _getTempFile(name):
+    prefix = 'supervisor.{0}.'.format(name)
+    return tempfile.NamedTemporaryFile(prefix=prefix)
+
+logger = logging.getLogger(__name__)
 
 class OptionTests(unittest.TestCase):
 
@@ -1636,28 +1643,40 @@ class TestProcessConfig(unittest.TestCase):
     def test_make_dispatchers_stderr_not_redirected(self):
         options = DummyOptions()
         instance = self._makeOne(options)
-        instance.redirect_stderr = False
-        process1 = DummyProcess(instance)
-        dispatchers, pipes = instance.make_dispatchers(process1)
-        self.assertEqual(dispatchers[5].channel, 'stdout')
-        from supervisor.events import ProcessCommunicationStdoutEvent
-        self.assertEqual(dispatchers[5].event_type,
-                         ProcessCommunicationStdoutEvent)
-        self.assertEqual(pipes['stdout'], 5)
-        self.assertEqual(dispatchers[7].channel, 'stderr')
-        from supervisor.events import ProcessCommunicationStderrEvent
-        self.assertEqual(dispatchers[7].event_type,
-                         ProcessCommunicationStderrEvent)
-        self.assertEqual(pipes['stderr'], 7)
+        with _getTempFile('stderr_logfile') as stdout_logfile:
+            with _getTempFile('stderr_logfile') as stderr_logfile:
+                instance.stdout_logfile = stdout_logfile.name
+                instance.stderr_logfile = stderr_logfile.name
+                logger.debug('instance.stdout_logfile = %r',
+                             instance.stdout_logfile)
+                logger.debug('instance.stderr_logfile = %r',
+                             instance.stderr_logfile)
+                instance.redirect_stderr = False
+                process1 = DummyProcess(instance)
+                dispatchers, pipes = instance.make_dispatchers(process1)
+                self.assertEqual(dispatchers[5].channel, 'stdout')
+                from supervisor.events import ProcessCommunicationStdoutEvent
+                self.assertEqual(dispatchers[5].event_type,
+                                 ProcessCommunicationStdoutEvent)
+                self.assertEqual(pipes['stdout'], 5)
+                self.assertEqual(dispatchers[7].channel, 'stderr')
+                from supervisor.events import ProcessCommunicationStderrEvent
+                self.assertEqual(dispatchers[7].event_type,
+                                 ProcessCommunicationStderrEvent)
+                self.assertEqual(pipes['stderr'], 7)
 
     def test_make_dispatchers_stderr_redirected(self):
         options = DummyOptions()
         instance = self._makeOne(options)
-        process1 = DummyProcess(instance)
-        dispatchers, pipes = instance.make_dispatchers(process1)
-        self.assertEqual(dispatchers[5].channel, 'stdout')
-        self.assertEqual(pipes['stdout'], 5)
-        self.assertEqual(pipes['stderr'], None)
+        with _getTempFile('stderr_logfile') as stdout_logfile:
+            instance.stdout_logfile = stdout_logfile.name
+            logger.debug('instance.stdout_logfile = %r',
+                         instance.stdout_logfile)
+            process1 = DummyProcess(instance)
+            dispatchers, pipes = instance.make_dispatchers(process1)
+            self.assertEqual(dispatchers[5].channel, 'stdout')
+            self.assertEqual(pipes['stdout'], 5)
+            self.assertEqual(pipes['stderr'], None)
 
 class FastCGIProcessConfigTest(unittest.TestCase):
     def _getTargetClass(self):
@@ -1697,21 +1716,29 @@ class FastCGIProcessConfigTest(unittest.TestCase):
     def test_make_dispatchers(self):
         options = DummyOptions()
         instance = self._makeOne(options)
-        instance.redirect_stderr = False
-        process1 = DummyProcess(instance)
-        dispatchers, pipes = instance.make_dispatchers(process1)
-        self.assertEqual(dispatchers[4].channel, 'stdin')
-        self.assertEqual(dispatchers[4].closed, True)
-        self.assertEqual(dispatchers[5].channel, 'stdout')
-        from supervisor.events import ProcessCommunicationStdoutEvent
-        self.assertEqual(dispatchers[5].event_type,
-                         ProcessCommunicationStdoutEvent)
-        self.assertEqual(pipes['stdout'], 5)
-        self.assertEqual(dispatchers[7].channel, 'stderr')
-        from supervisor.events import ProcessCommunicationStderrEvent
-        self.assertEqual(dispatchers[7].event_type,
-                         ProcessCommunicationStderrEvent)
-        self.assertEqual(pipes['stderr'], 7)
+        with _getTempFile('stderr_logfile') as stdout_logfile:
+            with _getTempFile('stderr_logfile') as stderr_logfile:
+                instance.stdout_logfile = stdout_logfile.name
+                instance.stderr_logfile = stderr_logfile.name
+                logger.debug('instance.stdout_logfile = %r',
+                             instance.stdout_logfile)
+                logger.debug('instance.stderr_logfile = %r',
+                             instance.stderr_logfile)
+                instance.redirect_stderr = False
+                process1 = DummyProcess(instance)
+                dispatchers, pipes = instance.make_dispatchers(process1)
+                self.assertEqual(dispatchers[4].channel, 'stdin')
+                self.assertEqual(dispatchers[4].closed, True)
+                self.assertEqual(dispatchers[5].channel, 'stdout')
+                from supervisor.events import ProcessCommunicationStdoutEvent
+                self.assertEqual(dispatchers[5].event_type,
+                                 ProcessCommunicationStdoutEvent)
+                self.assertEqual(pipes['stdout'], 5)
+                self.assertEqual(dispatchers[7].channel, 'stderr')
+                from supervisor.events import ProcessCommunicationStderrEvent
+                self.assertEqual(dispatchers[7].event_type,
+                                 ProcessCommunicationStderrEvent)
+                self.assertEqual(pipes['stderr'], 7)
 
 class ProcessGroupConfigTests(unittest.TestCase):
     def _getTargetClass(self):


### PR DESCRIPTION
by modifying 3 tests to use `instance.std{out,err}_logfile` which are temp files.

This is an alternative solution to the issue mentioned in #382, #377, and #417.
### Before:

```
$ /bin/rm std*_logfile
$ ls -l std*_logfile
zsh: no matches found: std*_logfile
$ tox -e py26
...
$ ls -l std*_logfile
-rw-r--r--  1 marca  staff     0B Apr 14 08:29 stderr_logfile
-rw-r--r--  1 marca  staff     0B Apr 14 08:29 stdout_logfile
```
### After:

```
$ /bin/rm std*_logfile
$ ls -l std*_logfile
zsh: no matches found: std*_logfile
$ tox -e py26
...
$ ls -l std*_logfile
zsh: no matches found: std*_logfile
```

Cc: @mnaberez, @mcdonc, @gcarothers, @graffic
