### PR TITLE
tox.ini: Remove old comments about Travis and py24

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,3 @@
-# !!! When making changes, make sure to also edit .travis.yml !!!
-
-# Note: Supervisor supports Python 2.4 but "py24" is not listed in envlist
-# because tox has a dependency on distribute, which no longer supports 2.4.
-
 [tox]
 envlist =
     py26,py27,py32,py33,py34,cover


### PR DESCRIPTION
These comments no longer apply since:
- `.travis.yml` is now a thin wrapper around `tox.ini`
- Supervisor 4.x will only support Python ≥ 2.6
