### PR TITLE
Document the supported versions of Python in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,14 @@ CLASSIFIERS = [
     'Topic :: System :: Boot',
     'Topic :: System :: Monitoring',
     'Topic :: System :: Systems Administration',
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 2",
+    "Programming Language :: Python :: 2.6",
+    "Programming Language :: Python :: 2.7",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.2",
+    "Programming Language :: Python :: 3.3",
+    "Programming Language :: Python :: 3.4",
 ]
 
 version_txt = os.path.join(here, 'supervisor/version.txt')


### PR DESCRIPTION
This lets tools like "caniusepython3" introspect correctly.
