### PR TITLE
Try to fix tailf got nothing on Chrome

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ htmlcov/
 tmp/
 coverage.xml
 nosetests.xml
+.idea/*

--- a/supervisor/http.py
+++ b/supervisor/http.py
@@ -650,7 +650,7 @@ class tail_f_producer:
             self.file.seek(-bytes_added, 2)
             bytes = self.file.read(bytes_added)
             self.sz = newsz
-            return '<pre style="word-wrap: break-word;">{0}</pre>'.format(cgi.escape(bytes))
+            return '<pre style="word-wrap: break-word;">{0}</pre>'.format(cgi.escape(bytes.decode('utf-8')))
         return NOT_DONE_YET
 
     def fsize(self):

--- a/supervisor/http.py
+++ b/supervisor/http.py
@@ -647,7 +647,7 @@ class tail_f_producer:
             return "==> File truncated <==\n"
         if bytes_added > 0:
             self.file.seek(-bytes_added, 2)
-            bytes = self.file.read(bytes_added)
+            bytes = '<p>{}</p>'.format(self.file.read(bytes_added))
             self.sz = newsz
             return bytes
         return NOT_DONE_YET
@@ -712,7 +712,7 @@ class logtail_handler:
 
         mtime = os.stat(logfile)[stat.ST_MTIME]
         request['Last-Modified'] = http_date.build_http_date(mtime)
-        request['Content-Type'] = 'text/plain'
+        request['Content-Type'] = 'text/html'
         # the lack of a Content-Length header makes the outputter
         # send a 'Transfer-Encoding: chunked' response
 
@@ -743,7 +743,7 @@ class mainlogtail_handler:
 
         mtime = os.stat(logfile)[stat.ST_MTIME]
         request['Last-Modified'] = http_date.build_http_date(mtime)
-        request['Content-Type'] = 'text/plain'
+        request['Content-Type'] = 'text/html'
         # the lack of a Content-Length header makes the outputter
         # send a 'Transfer-Encoding: chunked' response
 

--- a/supervisor/http.py
+++ b/supervisor/http.py
@@ -647,9 +647,9 @@ class tail_f_producer:
             return "==> File truncated <==\n"
         if bytes_added > 0:
             self.file.seek(-bytes_added, 2)
-            bytes = '<p>{}</p>'.format(self.file.read(bytes_added))
+            bytes = self.file.read(bytes_added)
             self.sz = newsz
-            return bytes
+            return '<p>{0}</p>'.format(bytes)
         return NOT_DONE_YET
 
     def fsize(self):

--- a/supervisor/http.py
+++ b/supervisor/http.py
@@ -1,3 +1,4 @@
+import cgi
 import os
 import stat
 import time
@@ -649,7 +650,7 @@ class tail_f_producer:
             self.file.seek(-bytes_added, 2)
             bytes = self.file.read(bytes_added)
             self.sz = newsz
-            return '<p>{0}</p>'.format(bytes)
+            return '<pre style="word-wrap: break-word;">{0}</pre>'.format(cgi.escape(bytes))
         return NOT_DONE_YET
 
     def fsize(self):

--- a/supervisor/tests/test_http.py
+++ b/supervisor/tests/test_http.py
@@ -19,6 +19,8 @@ from supervisor.tests.base import DummyRequest
 
 from supervisor.http import NOT_DONE_YET
 
+TAILF_LOG_WRAPPER = '<p>{0}</p>'
+
 class HandlerTests:
     def _makeOne(self, supervisord):
         return self._getTargetClass()(supervisord)
@@ -68,7 +70,7 @@ class LogtailHandlerTests(HandlerTests, unittest.TestCase):
         from supervisor.medusa import http_date
         self.assertEqual(request.headers['Last-Modified'],
                          http_date.build_http_date(os.stat(t)[stat.ST_MTIME]))
-        self.assertEqual(request.headers['Content-Type'], 'text/plain')
+        self.assertEqual(request.headers['Content-Type'], 'text/html')
         self.assertEqual(len(request.producers), 1)
         self.assertEqual(request._done, True)
 
@@ -104,7 +106,7 @@ class MainLogTailHandlerTests(HandlerTests, unittest.TestCase):
         from supervisor.medusa import http_date
         self.assertEqual(request.headers['Last-Modified'],
                          http_date.build_http_date(os.stat(t)[stat.ST_MTIME]))
-        self.assertEqual(request.headers['Content-Type'], 'text/plain')
+        self.assertEqual(request.headers['Content-Type'], 'text/html')
         self.assertEqual(len(request.producers), 1)
         self.assertEqual(request._done, True)
 
@@ -126,11 +128,11 @@ class TailFProducerTests(unittest.TestCase):
         t = f.name
         producer = self._makeOne(request, t, 80)
         result = producer.more()
-        self.assertEqual(result, as_bytes('a' * 80))
+        self.assertEqual(result, TAILF_LOG_WRAPPER.format(as_bytes('a' * 80)))
         f.write(as_bytes('w' * 100))
         f.flush()
         result = producer.more()
-        self.assertEqual(result, as_bytes('w' * 100))
+        self.assertEqual(result, TAILF_LOG_WRAPPER.format(as_bytes('w' * 100)))
         result = producer.more()
         self.assertEqual(result, http.NOT_DONE_YET)
         f.truncate(0)

--- a/supervisor/tests/test_http.py
+++ b/supervisor/tests/test_http.py
@@ -129,11 +129,11 @@ class TailFProducerTests(unittest.TestCase):
         t = f.name
         producer = self._makeOne(request, t, 80)
         result = producer.more()
-        self.assertEqual(result, TAILF_LOG_WRAPPER.format(cgi.escape(as_bytes('a' * 80))))
+        self.assertEqual(result, TAILF_LOG_WRAPPER.format(cgi.escape(as_bytes('a' * 80).decode('utf-8'))))
         f.write(as_bytes('w' * 100))
         f.flush()
         result = producer.more()
-        self.assertEqual(result, TAILF_LOG_WRAPPER.format(cgi.escape(as_bytes('w' * 100))))
+        self.assertEqual(result, TAILF_LOG_WRAPPER.format(cgi.escape(as_bytes('w' * 100).decode('utf-8'))))
         result = producer.more()
         self.assertEqual(result, http.NOT_DONE_YET)
         f.truncate(0)

--- a/supervisor/tests/test_http.py
+++ b/supervisor/tests/test_http.py
@@ -1,4 +1,5 @@
 import base64
+import cgi
 import os
 import stat
 import sys
@@ -19,7 +20,7 @@ from supervisor.tests.base import DummyRequest
 
 from supervisor.http import NOT_DONE_YET
 
-TAILF_LOG_WRAPPER = '<p>{0}</p>'
+TAILF_LOG_WRAPPER = '<pre style="word-wrap: break-word;">{0}</pre>'
 
 class HandlerTests:
     def _makeOne(self, supervisord):
@@ -128,11 +129,11 @@ class TailFProducerTests(unittest.TestCase):
         t = f.name
         producer = self._makeOne(request, t, 80)
         result = producer.more()
-        self.assertEqual(result, TAILF_LOG_WRAPPER.format(as_bytes('a' * 80)))
+        self.assertEqual(result, TAILF_LOG_WRAPPER.format(cgi.escape(as_bytes('a' * 80))))
         f.write(as_bytes('w' * 100))
         f.flush()
         result = producer.more()
-        self.assertEqual(result, TAILF_LOG_WRAPPER.format(as_bytes('w' * 100)))
+        self.assertEqual(result, TAILF_LOG_WRAPPER.format(cgi.escape(as_bytes('w' * 100))))
         result = producer.more()
         self.assertEqual(result, http.NOT_DONE_YET)
         f.truncate(0)


### PR DESCRIPTION
issue #149 

I have tested Chrome behavior about chunked response. The `Content-Type` should be `text/html` and response content must be a valid html element format, so I wrapped every log row in a `p` element, it is not very beautiful, but it works for me. 

My Chrome Version is 35.0.1916.153 (Official Build 274914) on MacOS.

Here is my test chunked response code, a piece of nodejs code.
```javascript
var http = require('http');

http.createServer(function (request, response) {
    response.writeHead(200, {
        'Content-Type': 'text/html',
        'Transfer-Encoding': 'chunked'
    });
    var x = setInterval(function(){
        response.write('<p>' + new Date() + '</p>' + '\r\n'); 
    }, 1000);
}).listen(8000);
```