### PR TITLE
Use monotonic time for process state tracking

### DIFF
--- a/supervisor/compat.py
+++ b/supervisor/compat.py
@@ -151,3 +151,37 @@ try: # pragma: no cover
     import thread
 except ImportError: # pragma: no cover
     import _thread as thread
+
+try: # pragma: no cover
+    from time import monotonic as monotonic_time
+except ImportError: # pragma: no cover
+    if sys.platform.startswith("linux") or sys.platform.contains("bsd"):
+        # Adapted from http://stackoverflow.com/questions/1205722/
+        import ctypes
+        import os
+
+        class timespec(ctypes.Structure):
+            _fields_ = [
+                ('tv_sec', ctypes.c_long),
+                ('tv_nsec', ctypes.c_long)
+            ]
+
+        if sys.platform.startswith("linux"):
+            librt = ctypes.CDLL('librt.so.1', use_errno=True)
+            clock_gettime = librt.clock_gettime
+            clock_gettime.argtypes = [ctypes.c_int32, ctypes.POINTER(timespec)]
+            CLOCK_MONOTONIC = 4  # see <linux/time.h>; CLOCK_MONOTONIC_RAW
+        elif sys.platform.contains("bsd"):
+            libc = ctypes.CDLL('libc.so', use_errno=True)
+            clock_gettime = libc.clock_gettime
+            clock_gettime.argtypes = [ctypes.c_int32, ctypes.POINTER(timespec)]
+            CLOCK_MONOTONIC = 4  # see <time.h>
+
+        def monotonic_time():
+            t = timespec()
+            if clock_gettime(CLOCK_MONOTONIC, ctypes.pointer(t)) != 0:
+                errno_ = ctypes.get_errno()
+                raise OSError(errno_, os.strerror(errno_))
+            return t.tv_sec + t.tv_nsec * 1e-9
+    else:
+        from time import monotonic  # raises ImportError

--- a/supervisor/process.py
+++ b/supervisor/process.py
@@ -1,11 +1,11 @@
 import os
-import time
 import errno
 import shlex
 import traceback
 import signal
 
 from supervisor.compat import maxint
+from supervisor.compat import monotonic_time
 from supervisor.compat import StringIO
 from supervisor.compat import total_ordering
 
@@ -167,7 +167,7 @@ class Subprocess(object):
             events.notify(event)
 
         if new_state == ProcessStates.BACKOFF:
-            now = time.time()
+            now = monotonic_time()
             self.backoff += 1
             self.delay = now + self.backoff
 
@@ -202,7 +202,7 @@ class Subprocess(object):
         self.system_stop = 0
         self.administrative_stop = 0
 
-        self.laststart = time.time()
+        self.laststart = monotonic_time()
 
         self._assertInState(ProcessStates.EXITED, ProcessStates.FATAL,
                             ProcessStates.BACKOFF, ProcessStates.STOPPED)
@@ -262,7 +262,7 @@ class Subprocess(object):
         options.close_child_pipes(self.pipes)
         options.logger.info('spawned: %r with pid %s' % (self.config.name, pid))
         self.spawnerr = None
-        self.delay = time.time() + self.config.startsecs
+        self.delay = monotonic_time() + self.config.startsecs
         options.pidhistory[pid] = self
         return pid
 
@@ -365,7 +365,7 @@ class Subprocess(object):
         Return None if the signal was sent, or an error message string
         if an error occurred or if the subprocess is not running.
         """
-        now = time.time()
+        now = monotonic_time()
         options = self.config.options
 
         # Properly stop processes in BACKOFF state.
@@ -438,7 +438,7 @@ class Subprocess(object):
 
         es, msg = decode_wait_status(sts)
 
-        now = time.time()
+        now = monotonic_time()
         self.laststop = now
         processname = self.config.name
 
@@ -532,7 +532,7 @@ class Subprocess(object):
         return self.state
 
     def transition(self):
-        now = time.time()
+        now = monotonic_time()
         state = self.state
 
         logger = self.config.options.logger
@@ -760,7 +760,7 @@ class EventListenerPool(ProcessGroupBase):
                     dispatch_capable = True
         if dispatch_capable:
             if self.dispatch_throttle:
-                now = time.time()
+                now = monotonic_time()
                 if now - self.last_dispatch < self.dispatch_throttle:
                     return
             self.dispatch()
@@ -775,7 +775,7 @@ class EventListenerPool(ProcessGroupBase):
                 # to process any further events in the buffer
                 self._acceptEvent(event, head=True)
                 break
-        self.last_dispatch = time.time()
+        self.last_dispatch = monotonic_time()
 
     def _acceptEvent(self, event, head=False):
         # events are required to be instances

--- a/supervisor/rpcinterface.py
+++ b/supervisor/rpcinterface.py
@@ -6,6 +6,7 @@ import errno
 from supervisor.compat import as_string
 from supervisor.compat import unicode
 from supervisor.compat import basestring
+from supervisor.compat import monotonic_time
 
 from supervisor.options import readFile
 from supervisor.options import tailFile
@@ -292,12 +293,12 @@ class SupervisorNamespaceRPCInterface:
                 # function appears to not work (symptom: 2nd or 3rd
                 # call through, it forgets about 'started', claiming
                 # it's undeclared).
-                started.append(time.time())
+                started.append(monotonic_time())
 
             if not wait or not startsecs:
                 return True
 
-            t = time.time()
+            t = monotonic_time()
             runtime = (t - started[0])
             state = process.get_state()
 
@@ -512,7 +513,7 @@ class SupervisorNamespaceRPCInterface:
 
         start = int(process.laststart)
         stop = int(process.laststop)
-        now = int(time.time())
+        now = int(monotonic_time())
 
         state = process.get_state()
         spawnerr = process.spawnerr or ''

--- a/supervisor/supervisord.py
+++ b/supervisor/supervisord.py
@@ -31,10 +31,11 @@ Options:
 """
 
 import os
-import time
 import errno
 import select
 import signal
+
+from supervisor.compat import monotonic_time
 
 from supervisor.medusa import asyncore_25 as asyncore
 
@@ -147,7 +148,7 @@ class Supervisor:
 
         if unstopped:
             # throttle 'waiting for x to die' reports
-            now = time.time()
+            now = monotonic_time()
             if now > (self.lastshutdownreport + 3): # every 3 secs
                 names = [ p.config.name for p in unstopped ]
                 namestr = ', '.join(names)
@@ -266,7 +267,7 @@ class Supervisor:
         the period for the event type rolls over """
         if now is None:
             # now won't be None in unit tests
-            now = time.time()
+            now = monotonic_time()
         for event in events.TICK_EVENTS:
             period = event.period
             last_tick = self.ticks.get(period)


### PR DESCRIPTION
This makes sure system time changes (e.g. via ntp) doesn't result in odd assertion failures due to processes entering the running state before being started.

Lightly tested on Linux; the BSD code is untested (written based on `man clock_gettime` and FreeBSD headers).  Unfortunately I do not know how to fix it for OSX, and suspect that falling back to `time.time()` is a bad idea.

While running `tox` locally seems to pass, I do not know how much to trust it.

Fixes #281.