### PR TITLE
Doc fix: Line feed, not carriage return.

### DIFF
--- a/docs/events.rst
+++ b/docs/events.rst
@@ -260,7 +260,7 @@ After the event listener has processed the event serialization, in
 order to notify supervisord about the result, it should send back a
 result structure on its stdout.  A result structure is the word
 "RESULT", followed by a space, followed by the result length, followed
-by a carriage return, follwed by the result content.  For example,
+by a line feed, followed by the result content.  For example,
 ``RESULT 2\nOK`` is the result "OK".  Conventionally, an event
 listener will use either ``OK`` or ``FAIL`` as the result content.
 These strings have special meaning to the default result handler.
@@ -280,7 +280,7 @@ Once the listener is in the ``ACKNOWLEDGED`` state, it may either exit
 ``autorestart`` config parameter is ``true``), or it may continue
 running.  If it continues to run, in order to be placed back into the
 ``READY`` state by supervisord, it must send a ``READY`` token
-followed immediately by a carriage return to its stdout.
+followed immediately by a line feed to its stdout.
 
 Example Event Listener Implementation
 +++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
A small doc fix: "\n" is a line feed, not a carriage return.
