### PR TITLE
Fixes issue #501 and improves an error message

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -2041,7 +2041,7 @@ def expand(s, expansions, name):
     try:
         return s % expansions
     except KeyError as ex:
-        available = expansions.keys()
+        available = list(expansions.keys())
         available.sort()
         raise ValueError(
             'Format string %r for %r contains names (%s) which cannot be '


### PR DESCRIPTION
I was getting an error from my supervisor config due to having %(process_num)s
in the command field of a program. This is supposed to work, but apparently some
refactoring broke it accidentally. The reason is that we call saneget outside
the for-loop that sets the process_num value, and so the expansion fails.

This also improves the "Format string contains names which cannot be expanded"
error message, so that it displays a list of expansions variables that are
available.
