### PR TITLE
Fix #369 relative command path

### DIFF
--- a/supervisor/process.py
+++ b/supervisor/process.py
@@ -116,7 +116,11 @@ class Subprocess(object):
             raise BadCommand("command is empty")
 
         if "/" in program:
-            filename = program
+            if program.startswith('/'):
+                filename = program
+            else:
+                filename = os.path.join(self.config.directory, program)
+
             try:
                 st = self.config.options.stat(filename)
             except OSError:


### PR DESCRIPTION
The docs say:

```
The command can be either absolute (e.g. /path/to/programname) or relative (e.g. programname). 
If it is relative, the supervisord’s environment $PATH will be searched for the executable.
```

This fixes relative path like to/programname as stated in #369 .
