### PR TITLE
Added a "restartpause" option

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -848,6 +848,7 @@ class ServerOptions(Options):
         autorestart = auto_restart(get(section, 'autorestart', 'unexpected'))
         startsecs = integer(get(section, 'startsecs', 1))
         startretries = integer(get(section, 'startretries', 3))
+        restartpause = integer(get(section, 'restartpause', 0))
         stopsignal = signal_number(get(section, 'stopsignal', 'TERM'))
         stopwaitsecs = integer(get(section, 'stopwaitsecs', 10))
         stopasgroup = boolean(get(section, 'stopasgroup', 'false'))
@@ -948,6 +949,7 @@ class ServerOptions(Options):
                 autorestart=autorestart,
                 startsecs=startsecs,
                 startretries=startretries,
+                restartpause=restartpause,
                 uid=uid,
                 stdout_logfile=logfiles['stdout_logfile'],
                 stdout_capture_maxbytes = stdout_cmaxbytes,
@@ -1711,7 +1713,7 @@ class Config(object):
 class ProcessConfig(Config):
     req_param_names = [
         'name', 'uid', 'command', 'directory', 'umask', 'priority',
-        'autostart', 'autorestart', 'startsecs', 'startretries',
+        'autostart', 'autorestart', 'startsecs', 'startretries', 'restartpause',
         'stdout_logfile', 'stdout_capture_maxbytes',
         'stdout_events_enabled', 'stdout_syslog',
         'stdout_logfile_backups', 'stdout_logfile_maxbytes',


### PR DESCRIPTION
This allows to set a pause between the restarts of the program.

Typically, when you restart a database server, this can take few minutes and the backoff delay won't be enough. With a restart pause delay of something like 30 seconds, this becomes a lot less likely. 
The alternative is to increase the number of start retries, but on system startup and/or when many programs fail at the same time (usually for the same reason), it creates an unnecessary workload on the host.

This changes the behaviors in two scenarios:
* Applied on startup failure additionally to the backoff delay
* Applied on bad exit status

Default value is 0, which doesn't change the existing behavior.

It is mostly a proposal at this stage. We could also allow to change the backoff increment (which is hardcoded to 1 at the current stage) or only the backoff base delay.