### PR TITLE
More info in "Unexpected end of key/value pairs" error

### DIFF
--- a/supervisor/datatypes.py
+++ b/supervisor/datatypes.py
@@ -82,7 +82,8 @@ def dict_of_key_value_pairs(arg):
     while i < tokens_len:
         k_eq_v = tokens[i:i+3]
         if len(k_eq_v) != 3 or k_eq_v[1] != '=':
-            raise ValueError("Unexpected end of key/value pairs")
+            raise ValueError(
+                "Unexpected end of key/value pairs in value %r" % arg)
         D[k_eq_v[0]] = k_eq_v[2].strip('\'"')
         i += 4
     return D

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -781,6 +781,14 @@ class ServerOptions(Options):
 
     def processes_from_section(self, parser, section, group_name,
                                klass=None):
+        try:
+            return self._processes_from_section(
+                parser, section, group_name, klass)
+        except ValueError as e:
+            raise ValueError('%s in section %r' % (e, section))
+
+    def _processes_from_section(self, parser, section, group_name,
+                                klass=None):
         if klass is None:
             klass = ProcessConfig
         programs = []

--- a/supervisor/tests/test_options.py
+++ b/supervisor/tests/test_options.py
@@ -970,6 +970,27 @@ class ServerOptionsTests(unittest.TestCase):
         self.assertRaises(ValueError, instance.processes_from_section,
                           config, 'program:foo', None)
 
+    def test_processes_from_section_unexpected_end_of_key_value_pairs(self):
+        instance = self._makeOne()
+        text = lstrip("""\
+        [program:foo]
+        command = /bin/cat
+        environment = KEY1=val1,KEY2=val2,KEY3
+        """)
+        from supervisor.options import UnhosedConfigParser
+        config = UnhosedConfigParser()
+        config.read_string(text)
+        try:
+            instance.processes_from_section(config, 'program:foo', None)
+        except ValueError as e:
+            self.assertEqual(
+                str(e),
+                "Unexpected end of key/value pairs in value "
+                "'KEY1=val1,KEY2=val2,KEY3' in section 'program:foo'")
+        else:
+            self.fail('instance.processes_from_section should '
+                      'raise a ValueError')
+
     def test_processes_from_autolog_without_rollover(self):
         instance = self._makeOne()
         text = lstrip("""\


### PR DESCRIPTION
Previously it was hard to know where the error was coming from if you had a large number of include files. E.g.:

```
$ supervisord
Error: Unexpected end of key/value pairs
For help, use /usr/local/bin/supervisord -h
```

This makes it easier by printing the string value and the section in which it occurred. E.g.:

```
$ supervisord --nodaemon -c supervisor.conf
Error: Unexpected end of key/value pairs in value 'KEY=val,KEY2=val,KEY3' in section 'program:hello'
For help, use /Users/marca/python/virtualenvs/supervisor/bin/supervisord -h
```
