### PR TITLE
Determine which file an error occurs in

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -834,7 +834,9 @@ class ServerOptions(Options):
             return self._processes_from_section(
                 parser, section, group_name, klass)
         except ValueError as e:
-            raise ValueError('%s in section %r' % (e, section))
+            filename = parser.section_to_file.get(section, '???')
+            raise ValueError('%s in section %r (file: %s)'
+                             % (e, section, filename))
 
     def _processes_from_section(self, parser, section, group_name,
                                 klass=None):
@@ -1657,6 +1659,10 @@ _marker = []
 class UnhosedConfigParser(ConfigParser.RawConfigParser):
     mysection = 'supervisord'
 
+    def __init__(self, *args, **kwargs):
+        ConfigParser.RawConfigParser.__init__(self, *args, **kwargs)
+        self.section_to_file = {}
+
     def read_string(self, s):
         s = StringIO(s)
         try:
@@ -1683,6 +1689,20 @@ class UnhosedConfigParser(ConfigParser.RawConfigParser):
     def getdefault(self, option, default=_marker, expansions={}, **kwargs):
         return self.saneget(self.mysection, option, default=default,
                             expansions=expansions, **kwargs)
+
+    def read(self, filenames):
+        sections_orig = self._sections.copy()
+        filenames = ConfigParser.RawConfigParser.read(self, filenames)
+
+        if len(filenames) == 1:
+            filename = filenames[0]
+        else:
+            filename = '???'
+
+        for section in frozenset(self._sections) - frozenset(sections_orig):
+            self.section_to_file[section] = filename
+
+        return filenames
 
 
 class Config(object):

--- a/supervisor/tests/test_options.py
+++ b/supervisor/tests/test_options.py
@@ -1399,10 +1399,10 @@ class ServerOptionsTests(unittest.TestCase):
         try:
             instance.processes_from_section(config, 'program:foo', None)
         except ValueError as e:
-            self.assertEqual(
-                str(e),
+            self.assertTrue(
                 "Unexpected end of key/value pairs in value "
-                "'KEY1=val1,KEY2=val2,KEY3' in section 'program:foo'")
+                "'KEY1=val1,KEY2=val2,KEY3' in section 'program:foo'"
+                in str(e))
         else:
             self.fail('instance.processes_from_section should '
                       'raise a ValueError')


### PR DESCRIPTION
I found a way to display what file an error occurred in, by doing some further extension of [`UnhosedConfigParser`](https://github.com/Supervisor/supervisor/pull/516/files#diff-0240b66c1a20db854f3d6eacb71caa32L1657).

Example:

```
$ supervisord --nodaemon -c supervisor.conf
Error: Unexpected end of key/value pairs in value 'KEY=val,KEY2=val,KEY3' in section 'program:foo' (file: /Users/marca/dev/git-repos/supervisor/test_conf.d/foo.conf)
For help, use /Users/marca/python/virtualenvs/supervisor/bin/supervisord -h
```
