### PR TITLE
tox.ini: Don't repeat dependencies

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,7 @@ basepython =
 commands =
     python setup.py nosetests --with-xunit --with-xcoverage --cover-package=supervisor --cover-erase
 deps =
-    meld3 >= 1.0.0
-    mock >= 0.5.0
+    {[testenv]deps}
     nose
     coverage
     nosexcover
@@ -27,8 +26,4 @@ basepython =
 commands =
     python setup.py nosetests --with-xunit --with-xcoverage --cover-package=supervisor --cover-erase
 deps =
-    meld3 >= 1.0.0
-    mock >= 0.5.0
-    nose
-    coverage
-    nosexcover
+    {[testenv:cover]deps}


### PR DESCRIPTION
by using substitutions from other sections.
