### PR TITLE
test_options_unixsocket_configfile: Don't use argv

### DIFF
--- a/supervisor/tests/test_options.py
+++ b/supervisor/tests/test_options.py
@@ -397,7 +397,7 @@ class ClientOptionsTests(unittest.TestCase):
         fp = StringIO(s)
         instance = self._makeOne()
         instance.configfile = fp
-        instance.realize()
+        instance.realize(())
         self.assertEqual(instance.serverurl, 'unix:///dev/null')
 
 class ServerOptionsTests(unittest.TestCase):


### PR DESCRIPTION
Without this, if you invoke a test command that has command-line options, `supervisor.options` will try to parse those options and can fail because of unrecognized options:

```
$ .tox/py27/bin/py.test -v supervisor/tests/test_options.py -k test_options_unixsocket_configfile
...
self = <supervisor.options.ClientOptions instance at 0x103aeb050>,
msg = GetoptError('option -v not recognized', 'v')

    def usage(self, msg):
        """Print a brief error message to stderr and exit(2)."""
        self.stderr.write("Error: %s\n" % str(msg))
        self.stderr.write("For help, use %s -h\n" % self.progname)
>       self.exit(2)
E       SystemExit: 2

supervisor/options.py:143: SystemExit
-----------------------------------------------------------------------------
Captured stderr call
-----------------------------------------------------------------------------
Error: option -v not recognized
...
```

Changed `test_options_unixsocket_configfile` to explictly set `arg` to an empty tuple so that `*arg is not None` and it doesn't pull args from `sys.argv`.

Output:

```
$ .tox/py27/bin/py.test -v supervisor/tests/test_options.py -k test_options_unixsocket_configfile
...
supervisor/tests/test_options.py::ClientOptionsTests::test_options_unixsocket_configfile PASSED
...
```
