### PR TITLE
tox.ini: Switch to use py.test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,10 @@ if py_version < (3, 3):
     tests_require.append('mock')
 
 testing_extras = tests_require + [
-    'nose',
-    'coverage',
+    'pytest',
+    'pytest-cov',
     ]
-    
+
 from setuptools import setup, find_packages
 here = os.path.abspath(os.path.dirname(__file__))
 try:
@@ -71,7 +71,7 @@ dist = setup(
     license='BSD-derived (http://www.repoze.org/LICENSE.txt)',
     url='http://supervisord.org/',
     description="A system for controlling process state under UNIX",
-    long_description=README + '\n\n' +  CHANGES,
+    long_description=README + '\n\n' + CHANGES,
     classifiers=CLASSIFIERS,
     author="Chris McDonough",
     author_email="chrism@plope.com",
@@ -80,19 +80,19 @@ dist = setup(
     packages=find_packages(),
     install_requires=requires,
     extras_require={
-        'iterparse':['cElementTree >= 1.0.2'],
-        'testing':testing_extras,
+        'iterparse': ['cElementTree >= 1.0.2'],
+        'testing': testing_extras,
         },
     tests_require=tests_require,
     include_package_data=True,
     zip_safe=False,
     test_suite="supervisor.tests",
     entry_points={
-     'console_scripts': [
-         'supervisord = supervisor.supervisord:main',
-         'supervisorctl = supervisor.supervisorctl:main',
-         'echo_supervisord_conf = supervisor.confecho:main',
-         'pidproxy = supervisor.pidproxy:main',
+        'console_scripts': [
+            'supervisord = supervisor.supervisord:main',
+            'supervisorctl = supervisor.supervisorctl:main',
+            'echo_supervisord_conf = supervisor.confecho:main',
+            'pidproxy = supervisor.pidproxy:main',
         ],
     },
 )

--- a/tox.ini
+++ b/tox.ini
@@ -3,27 +3,24 @@ envlist =
     cover,cover3,py26,py27,py32,py33,py34,pypy
 
 [testenv]
-commands =
-    python setup.py test -q
 deps =
+    pytest >= 2.5.2
     meld3 >= 1.0.0
     mock >= 0.5.0
+commands =
+    py.test {posargs}
 
 [testenv:cover]
-basepython =
-    python2.6
+basepython = python2.6
 commands =
-    python setup.py nosetests --with-xunit --with-xcoverage --cover-package=supervisor --cover-erase
+    py.test --cov=supervisor --cov-report=term-missing --cov-report=xml {posargs}
 deps =
     {[testenv]deps}
-    nose
-    coverage
-    nosexcover
+    pytest-cov
 
 [testenv:cover3]
-basepython =
-    python3.3
+basepython = python3.3
 commands =
-    python setup.py nosetests --with-xunit --with-xcoverage --cover-package=supervisor --cover-erase
+    py.test --cov=supervisor --cov-report=term-missing --cov-report=xml {posargs}
 deps =
     {[testenv:cover]deps}


### PR DESCRIPTION
because it's awesome.

This might be more controversial, since test runners can be a bit of a religion... :smile: 

`py.test` can take a bunch of different arguments so I added `{posargs}` to the `tox.ini` so that options can be passed from a `tox` command to the underlying `py.test`. For example:

```
$ tox -e py27,py34 -- --tb=short --showlocals --durations=5 supervisor/tests/test_supervisorctl.py
GLOB sdist-make: /Users/marca/dev/git-repos/supervisor/setup.py
py27 inst-nodeps: /Users/marca/dev/git-repos/supervisor/.tox/dist/supervisor-4.0.0-dev.zip
py27 runtests: PYTHONHASHSEED='2805401122'
py27 runtests: commands[0] | py.test --tb=short --showlocals --durations=5 supervisor/tests/test_supervisorctl.py
============================================================================= test session starts ==============================================================================
platform darwin -- Python 2.7.6 -- py-1.4.26 -- pytest-2.6.4
collected 193 items

supervisor/tests/test_supervisorctl.py .................................................................................................................................................................................................

=========================================================================== slowest 5 test durations ===========================================================================
0.00s call     supervisor/tests/test_supervisorctl.py::fgthread_Tests::test_ctor
0.00s call     supervisor/tests/test_supervisorctl.py::test_suite
0.00s call     supervisor/tests/test_supervisorctl.py::TestDefaultControllerPlugin::test_maintail_dashf
0.00s setup    supervisor/tests/test_supervisorctl.py::ControllerTests::test__upcheck_reraises_other_xmlrpc_faults
0.00s call     supervisor/tests/test_supervisorctl.py::ControllerTests::test__upcheck
========================================================================== 193 passed in 0.31 seconds ==========================================================================
py34 inst-nodeps: /Users/marca/dev/git-repos/supervisor/.tox/dist/supervisor-4.0.0-dev.zip
py34 runtests: PYTHONHASHSEED='2805401122'
py34 runtests: commands[0] | py.test --tb=short --showlocals --durations=5 supervisor/tests/test_supervisorctl.py
============================================================================= test session starts ==============================================================================
platform darwin -- Python 3.4.0 -- py-1.4.26 -- pytest-2.6.4
collected 193 items

supervisor/tests/test_supervisorctl.py .................................................................................................................................................................................................

=========================================================================== slowest 5 test durations ===========================================================================
0.01s call     supervisor/tests/test_supervisorctl.py::TestDefaultControllerPlugin::test_maintail_dashf
0.00s call     supervisor/tests/test_supervisorctl.py::fgthread_Tests::test_ctor
0.00s call     supervisor/tests/test_supervisorctl.py::test_suite
0.00s call     supervisor/tests/test_supervisorctl.py::ControllerTests::test__upcheck
0.00s call     supervisor/tests/test_supervisorctl.py::TestDefaultControllerPlugin::test_tail_failed
========================================================================== 193 passed in 0.37 seconds ==========================================================================
___________________________________________________________________________________ summary ____________________________________________________________________________________
  py27: commands succeeded
  py34: commands succeeded
  congratulations :)
```

or

```
$ .tox/py27/bin/py.test -k test_no_config_file_exits -v
============================================================================= test session starts ==============================================================================
platform darwin -- Python 2.7.6 -- py-1.4.26 -- pytest-2.6.4 -- /Users/marca/dev/git-repos/supervisor/.tox/py27/bin/python2.7
collected 1141 items

supervisor/tests/test_options.py::ServerOptionsTests::test_no_config_file_exits PASSED

============================================================ 1140 tests deselected by '-ktest_no_config_file_exits' ============================================================
============================================================ 1 passed, 1140 deselected, 1 warnings in 0.74 seconds =============================================================
```

I often find it very useful in particular to run just a single test or a small subset of the tests. The supervisor test suite is pretty darned fast at this point so it's not a huge deal but maybe it could be later if we added more extensive integration tests.

[pytest's fixture mechanism (dependency injection)](http://pytest.org/latest/fixture.html) is pretty awesome too and can lead to powerful and succint tests.