### PR TITLE
supervisorctl read from ~/.supervisorctl.conf

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -110,6 +110,11 @@ class Options:
                        'supervisord.conf',
                        'etc/supervisord.conf',
                        '/etc/supervisord.conf']
+        if self.progname.endswith('supervisorctl'):
+            dot_supervisorctl_conf = os.path.join(
+                os.path.expanduser('~'),
+                '.supervisorctl.conf')
+            searchpaths.insert(0, dot_supervisorctl_conf)
         self.searchpaths = searchpaths
 
     def default_configfile(self):


### PR DESCRIPTION
This is a good place for users to do user-specific customizations, like change the prompt or add plug-ins.