### PR TITLE
Determine which file an error occurs in

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -811,7 +811,9 @@ class ServerOptions(Options):
             return self._processes_from_section(
                 parser, section, group_name, klass)
         except ValueError, e:
-            raise ValueError('%s in section %r' % (e, section))
+            filename = parser.section_to_file.get(section, '???')
+            raise ValueError('%s in section %r (file: %s)'
+                             % (e, section, filename))
 
     def _processes_from_section(self, parser, section, group_name,
                                 klass=None):
@@ -1616,6 +1618,11 @@ _marker = []
 
 class UnhosedConfigParser(ConfigParser.RawConfigParser):
     mysection = 'supervisord'
+
+    def __init__(self, *args, **kwargs):
+        ConfigParser.RawConfigParser.__init__(self, *args, **kwargs)
+        self.section_to_file = {}
+
     def read_string(self, s):
         from StringIO import StringIO
         s = StringIO(s)
@@ -1640,6 +1647,20 @@ class UnhosedConfigParser(ConfigParser.RawConfigParser):
     def getdefault(self, option, default=_marker, expansions={}, **kwargs):
         return self.saneget(self.mysection, option, default=default,
                             expansions=expansions, **kwargs)
+
+    def read(self, filenames):
+        sections_orig = self._sections.copy()
+        filenames = ConfigParser.RawConfigParser.read(self, filenames)
+
+        if len(filenames) == 1:
+            filename = filenames[0]
+        else:
+            filename = '???'
+
+        for section in frozenset(self._sections) - frozenset(sections_orig):
+            self.section_to_file[section] = filename
+
+        return filenames
 
 
 class Config(object):

--- a/supervisor/tests/test_options.py
+++ b/supervisor/tests/test_options.py
@@ -1208,10 +1208,10 @@ class ServerOptionsTests(unittest.TestCase):
         try:
             instance.processes_from_section(config, 'program:foo', None)
         except ValueError, e:
-            self.assertEqual(
-                str(e),
+            self.assertTrue(
                 "Unexpected end of key/value pairs in value "
-                "'KEY1=val1,KEY2=val2,KEY3' in section 'program:foo'")
+                "'KEY1=val1,KEY2=val2,KEY3' in section 'program:foo'"
+                in str(e))
         else:
             self.fail('instance.processes_from_section should '
                       'raise a ValueError')


### PR DESCRIPTION
cherry-pick enhancement from PR #516

```
$ supervisord
Error: Unexpected end of key/value pairs in value 'KEY=val,KEY2=val,KEY3' in section 'program:foo' (file: /Users/marca/dev/git-repos/supervisor/test_conf.d/foo.conf)
For help, use /Users/marca/python/virtualenvs/supervisor/bin/supervisord -h
```

```
git cherry-pick aaecdfd71fc027f125662eb0ec1de96e344b9615

Conflicts:
    supervisor/options.py
    supervisor/tests/test_options.py
```
