### PR TITLE
Colorized output for supervisorctl status

### DIFF
--- a/supervisor/colors.py
+++ b/supervisor/colors.py
@@ -1,0 +1,31 @@
+ESC = '\033['
+
+
+class ansicolors:
+    class fg:
+        black = ESC + '30m'
+        red = ESC + '31m'
+        green = ESC + '32m'
+        yellow = ESC + '33m'
+        blue = ESC + '34m'
+        magenta = ESC + '35m'
+        cyan = ESC + '36m'
+        white = ESC + '37m'
+        reset = ESC + '39m'
+
+    class bg:
+        black = ESC + '40m'
+        red = ESC + '41m'
+        green = ESC + '42m'
+        yellow = ESC + '43m'
+        blue = ESC + '44m'
+        magenta = ESC + '45m'
+        cyan = ESC + '46m'
+        white = ESC + '47m'
+        reset = ESC + '49m'
+
+    class style:
+        bright = ESC + '1m'
+        dim = ESC + '2m'
+        normal = ESC + '22m'
+        reset_all = ESC + '0m'

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -1557,6 +1557,7 @@ class ClientOptions(Options):
     username = None
     password = None
     history_file = None
+    colorize_status = False
 
     def __init__(self):
         Options.__init__(self, require_configfile=False)
@@ -1568,6 +1569,7 @@ class ClientOptions(Options):
         self.configroot.supervisorctl.username = None
         self.configroot.supervisorctl.password = None
         self.configroot.supervisorctl.history_file = None
+        self.configroot.supervisorctl.colorize_status = False
 
         from supervisor.supervisorctl import DefaultControllerPlugin
         default_factory = ('default', DefaultControllerPlugin, {})
@@ -1578,6 +1580,8 @@ class ClientOptions(Options):
         self.add("interactive", "supervisorctl.interactive", "i",
                  "interactive", flag=1, default=0)
         self.add("prompt", "supervisorctl.prompt", default="supervisor")
+        self.add("colorize_status", "supervisorctl.colorize_status",
+                 default=False)
         self.add("serverurl", "supervisorctl.serverurl", "s:", "serverurl=",
                  url, default="http://localhost:9001")
         self.add("username", "supervisorctl.username", "u:", "username=")
@@ -1627,6 +1631,7 @@ class ClientOptions(Options):
         # The defaults used below are really set in __init__ (since
         # section==self.configroot.supervisorctl)
         section.prompt = config.getdefault('prompt', section.prompt)
+        section.colorize_status = config.getdefault('colorize_status', section.colorize_status)
         section.username = config.getdefault('username', section.username)
         section.password = config.getdefault('password', section.password)
         history_file = config.getdefault('history_file', section.history_file)

--- a/supervisor/tests/test_supervisorctl.py
+++ b/supervisor/tests/test_supervisorctl.py
@@ -1832,6 +1832,7 @@ class DummyPluginFactory:
 class DummyClientOptions:
     def __init__(self):
         self.prompt = 'supervisor'
+        self.colorize_status = False
         self.serverurl = 'http://localhost:65532'
         self.username = 'chrism'
         self.password = '123'


### PR DESCRIPTION
How about a sexy new feature for 4.0...? :smile: 

I've long wanted this, because it makes the failed processes stand out from the OK ones in a long list.

![supervisorctl_status_colored](https://cloud.githubusercontent.com/assets/305268/5286368/885a5066-7ad8-11e4-8c76-643db94a266d.png)

I'm toying with the idea of colorizing the entire line rather than just the status. Or maybe the name and the status. Having the name colorized seems nice so that your eyes can just scan the first column. Kind of thinking of not colorizing the rest of the line according to status, because I had an idea of maybe colorizing the uptime if it less than a certain threshold (`startsecs`?) -- this is because we sometimes have processes that repeatedly spin up and die and use a lot of CPU, so it can be very useful sometimes to spot the processes that have the shortest uptime...

@mcdonc and @mnaberez: What do you guys think?

I didn't write tests, but I will add them if you're cool with the feature.
