### PR TITLE
Fix log format for http server and http channel objects

### DIFF
--- a/supervisor/supervisord.py
+++ b/supervisor/supervisord.py
@@ -217,7 +217,7 @@ class Supervisor:
                     try:
                         dispatcher = combined_map[fd]
                         self.options.logger.blather(
-                            'read event caused by %(dispatcher)s',
+                            'read event caused by %(dispatcher)r',
                             dispatcher=dispatcher)
                         dispatcher.handle_read_event()
                     except asyncore.ExitNow:
@@ -230,7 +230,7 @@ class Supervisor:
                     try:
                         dispatcher = combined_map[fd]
                         self.options.logger.blather(
-                            'write event caused by %(dispatcher)s',
+                            'write event caused by %(dispatcher)r',
                             dispatcher=dispatcher)
                         dispatcher.handle_write_event()
                     except asyncore.ExitNow:


### PR DESCRIPTION
I set log level to `blather` and then I access to http server `http://127.0.0.1:9001/`.
Next, I check the log file /tmp/supervisord.log  and it has the following lines:
(omitted date and time)

```
BLAT read event caused by <socket._socketobject object at 0x7fcb6ed6a750>
BLAT read event caused by <socket._socketobject object at 0x7fcb6ed2d590>
BLAT read event caused by <socket._socketobject object at 0x7fcb6ed2d590>
BLAT write event caused by <socket._socketobject object at 0x7fcb6ed2d590>
```

I think that the above lines don't make sense because they did not show object's module name and class name. They should show as follows:

```
BLAT read event caused by <supervisor.http.supervisor_af_inet_http_server listening :9001 at 0x7fccaad59560>
BLAT read event caused by <supervisor.http.deferring_http_channel connected 127.0.0.1:47391 at 0x7fccaabe1320 channel#: 0 requests:0>
BLAT read event caused by <supervisor.http.deferring_http_channel connected 127.0.0.1:47391 at 0x7fccaabe1320 channel#: 0 requests:1>
BLAT read event caused by <supervisor.http.deferring_http_channel connected 127.0.0.1:47391 at 0x7fccaabe1320 channel#: 0 requests:2>
```
