### PR TITLE
Add inline_comment_prefixes support to supervisorctl's config (for Py3)

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -1601,7 +1601,10 @@ class ClientOptions(Options):
                 need_close = True
             except (IOError, OSError):
                 raise ValueError("could not read config file %s" % fp)
-        config = UnhosedConfigParser()
+        kwargs = {}
+        if PY3:
+            kwargs['inline_comment_prefixes'] = (';','#')
+        config = UnhosedConfigParser(**kwargs)
         config.expansions = self.environ_expansions
         config.mysection = 'supervisorctl'
         try:


### PR DESCRIPTION
I configured supervisorctl's configuration as follows:

```
[supervisorctl]
serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
username=son                ; should be same as http_username if set
password=123                ; should be same as http_password if set
```

Next, I executed the command `supervisorctl` and the following error occurred:

```
[son@localhost ~]$ supervisorctl
unix:///tmp/supervisor.sock ; use a unix:/ URL  for a unix socket no such file
supervisor>
```
