### PR TITLE
set the environment for the supervisord process

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -630,6 +630,7 @@ class ServerOptions(Options):
         environ_str = get('environment', '')
         environ_str = expand(environ_str, expansions, 'environment')
         section.environment = dict_of_key_value_pairs(environ_str)
+        self.environment = section.environment
         # Process rpcinterface plugins before groups to allow custom events to
         # be registered.
         section.rpcinterface_factories = self.get_plugins(


### PR DESCRIPTION
If the supervisord.conf only has an extending rpcinterface, pay attention, **there is not any section [program:xxx]**, in this case, self.environment (the environment of ServerOptions) will never be assigned a value, which leads to two problems (given the example supervisord.conf as follows):
- the extending rpcinterface can not get the environment from os.environ
- the following function seems useless because **self.environment** never be assigned and **self.environment is None** 
  
  ```
  def process_environment(self):
    os.environ.update(self.environment or {}) 
  ```

This patch will fix this.

The example supervisord.conf and the background of this patch:

```
  [supervisord]
  logfile = /home/work/logtest/supervisord.log
  pidfile = /home/work/logtest/supervisord.pid
  subprocpidfile = /home/work/logtest/subprocess.pids
  environment=MYENV="true"

  [rpcinterface:supervisor]
  supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface

  [rpcinterface:myrpc]
  app_root = /home/work/apptest
  log_root = /home/work/logtest
  supervisor.rpcinterface_factory = myrpc.rpcinterface:myrpc_rpcinterface
```

**myrpc_rpcinterface** will get the environment MYENV in the supervisord section from os.environ.
Actually, myrpc_rpcinterface will generate the following config files of subprocess and reload them:

```
  [program:hello_subprocess]
  command = ...
  http_url = ...
```
