### PR TITLE
Attempt to fix %(here)s in included files. Fix #81, related to #84

### DIFF
--- a/supervisor/tests/fixtures/example/included.conf
+++ b/supervisor/tests/fixtures/example/included.conf
@@ -1,0 +1,2 @@
+[supervisord]
+childlogdir = %(here)s

--- a/supervisor/tests/fixtures/include.conf
+++ b/supervisor/tests/fixtures/include.conf
@@ -1,0 +1,5 @@
+[include]
+files = ./example/included.conf
+
+[supervisord]
+logfile = %(here)s

--- a/supervisor/tests/test_options.py
+++ b/supervisor/tests/test_options.py
@@ -2586,6 +2586,19 @@ class ServerOptionsTests(unittest.TestCase):
         instance.poller.before_daemonize.assert_called_once_with()
         instance.poller.after_daemonize.assert_called_once_with()
 
+    def test_include_here(self):
+        conf = os.path.join(
+            os.path.abspath(os.path.dirname(__file__)), 'fixtures',
+            'include.conf')
+        root_here = os.path.dirname(conf)
+        include_here = os.path.join(root_here, 'example')
+        parser = self._makeOne()
+        parser.configfile = conf
+        parser.process_config_file(True)
+        section = parser.configroot.supervisord
+        self.assertEqual(section.logfile, root_here)
+        self.assertEqual(section.childlogdir, include_here)
+
 class TestProcessConfig(unittest.TestCase):
     def _getTargetClass(self):
         from supervisor.options import ProcessConfig


### PR DESCRIPTION
I've been giving some thought and investigation and because of how ConfigParser is implemented (in 2.7 and 3.4) I couldn't come with more elegant solution.

Suggestions are welcome.

I'm using string replace instead of format because the same value can have multiple substitutions, for example: 
xx = %(here)s/%(program_name)s
