### PR TITLE
Compatibility information for Python 3 was out of date

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -162,5 +162,4 @@ It will likely work fine on most UNIX systems.
 
 Supervisor will *not* run at all under any version of Windows.
 
-Supervisor is known to work with Python 2.4 or later but will not work
-under any version of Python 3.
+Supervisor works under Python 2 version 2.6 or greater and Python 3 version 3.2 or greater.


### PR DESCRIPTION
https://github.com/Supervisor/supervisor/blob/master/docs/introduction.rst and http://supervisord.org/introduction.html#overview said that compatibility was [2.4, 3.0) when it should be >2.6 && >3.2.