### PR TITLE
Search user configuration directory for the configuration file

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -104,10 +104,14 @@ class Options:
         self.add(None, None, "h", "help", self.help)
         self.add("configfile", None, "c:", "configuration=")
 
+        default_userdir = os.path.join(os.environ['HOME'], '.config')
+        userdir = os.environ.get('XDG_CONFIG_HOME', default_userdir)
+
         here = os.path.dirname(os.path.dirname(sys.argv[0]))
         searchpaths = [os.path.join(here, 'etc', 'supervisord.conf'),
                        os.path.join(here, 'supervisord.conf'),
                        'supervisord.conf',
+                       os.path.join(userdir, 'supervisor', 'config.conf'),
                        'etc/supervisord.conf',
                        '/etc/supervisord.conf']
         self.searchpaths = searchpaths


### PR DESCRIPTION
This is a incomplete pull request. But I'd like to get some comments on this. I've been toying around with using supervisor to manage daemons in my user session for a light weight desktop (window manager, hoktkey listener, etc). One downside is having to specify the configuration file on the command line, since supervisor doesn't search in the users path.

Again, this is just a springboard PR for comments on the idea. I can add tests and make any changes based on comments, but the idea is there!