### PR TITLE
Unregister file descriptors when streams close.

### DIFF
--- a/supervisor/supervisord.py
+++ b/supervisor/supervisord.py
@@ -220,6 +220,9 @@ class Supervisor:
                             'read event caused by %(dispatcher)r',
                             dispatcher=dispatcher)
                         dispatcher.handle_read_event()
+                        if (not dispatcher.readable()
+                                and not dispatcher.writable()):
+                            self.options.poller.unregister(fd)
                     except asyncore.ExitNow:
                         raise
                     except:
@@ -233,6 +236,9 @@ class Supervisor:
                             'write event caused by %(dispatcher)r',
                             dispatcher=dispatcher)
                         dispatcher.handle_write_event()
+                        if (not dispatcher.readable()
+                                and not dispatcher.writable()):
+                            self.options.poller.unregister(fd)
                     except asyncore.ExitNow:
                         raise
                     except:


### PR DESCRIPTION
When I run MongoDB under Supervisor 4.0-dev, MongoDB closes its stdout stream and Supervisor reacts by spinning the CPU at 100%. This patch fixes the problem by unregistering file descriptors that are no longer readable or writable.

(Both MongoDB and Supervisor remained responsive; this bug was really just a pure CPU drain.)