### PR TITLE
status: Add --sort=start and --reverse options

### DIFF
--- a/supervisor/supervisorctl.py
+++ b/supervisor/supervisorctl.py
@@ -25,7 +25,7 @@ actions.
 import cmd
 import sys
 import getpass
-
+import operator
 import socket
 import errno
 import threading
@@ -612,8 +612,19 @@ class DefaultControllerPlugin(ControllerPluginBase):
 
         supervisor = self.ctl.get_supervisor()
         all_infos = supervisor.getAllProcessInfo()
+        sort_by_starttime = False
+        reverse = False
 
-        names = arg.split()
+        args = arg.split()
+
+        options = [arg for arg in args if arg.startswith('--')]
+        for option in options:
+            if option.startswith('--sort=start'):
+                sort_by_starttime = True
+            if option.startswith('--reverse'):
+                reverse = True
+
+        names = [arg for arg in args if not arg.startswith('--')]
         if not names or "all" in names:
             matching_infos = all_infos
         else:
@@ -638,6 +649,9 @@ class DefaultControllerPlugin(ControllerPluginBase):
                     else:
                         msg = "%s: ERROR (no such process)" % name
                     self.ctl.output(msg)
+        if sort_by_starttime:
+            matching_infos.sort(key=operator.itemgetter('start'),
+                                reverse=reverse)
         self._show_statuses(matching_infos)
 
     def help_status(self):


### PR DESCRIPTION
Proof of concept and request for feedback on the idea.

This will conflict with https://github.com/Supervisor/supervisor/pull/530, which also could use some new feedback.

This lets the `status` command sort by start time. I've often wished for this, because I deal with servers that are running tons of processes from different teams and when the system gets slow or wonky, it helps if I can see which processes were started most recently, as these are often ones that are flapping up and down and chewing up CPU (basically the issue in https://github.com/Supervisor/supervisor/issues/584).

```
[marca@marca-mac2 supervisor]$ supervisorctl status --sort=start
cat:0                            RUNNING   pid 25747, uptime 1 day, 2:11:57
cat:1                            RUNNING   pid 25746, uptime 1 day, 2:11:57
cat:3                            RUNNING   pid 25748, uptime 1 day, 2:11:57
cat:4                            RUNNING   pid 25750, uptime 1 day, 2:11:57
hello                            RUNNING   pid 25744, uptime 1 day, 2:11:57
dog:0                            FATAL     can't find command 'dog'
dog:1                            FATAL     can't find command 'dog'
dog:2                            FATAL     can't find command 'dog'
dog:3                            FATAL     can't find command 'dog'
dog:4                            FATAL     can't find command 'dog'
cat:2                            RUNNING   pid 69455, uptime 0:17:32
foo                              RUNNING   pid 69866, uptime 0:17:07

[marca@marca-mac2 supervisor]$ supervisorctl status --sort=start --reverse
foo                              RUNNING   pid 69866, uptime 0:17:09
cat:2                            RUNNING   pid 69455, uptime 0:17:34
dog:0                            FATAL     can't find command 'dog'
dog:1                            FATAL     can't find command 'dog'
dog:2                            FATAL     can't find command 'dog'
dog:3                            FATAL     can't find command 'dog'
dog:4                            FATAL     can't find command 'dog'
cat:0                            RUNNING   pid 25747, uptime 1 day, 2:11:59
cat:1                            RUNNING   pid 25746, uptime 1 day, 2:11:59
cat:3                            RUNNING   pid 25748, uptime 1 day, 2:11:59
cat:4                            RUNNING   pid 25750, uptime 1 day, 2:11:59
hello                            RUNNING   pid 25744, uptime 1 day, 2:11:59
```

If the idea of adding more options to `status` is okay, then I would change this to use more robust and extensible option parsing and would add tests.
