### PR TITLE
Url prefix for web interface

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -51,6 +51,10 @@
 - Files included via the `[include]` section are read in sorted order.  In
   past versions, the order was undefined.  Patch by Ionel Cristian Mărieș.
 
+- Added ``base_path`` option in the `[inet_http_server]` section. This
+  allows to put the web interface behind a reverse proxy (i.e. web server).
+  The default value is ``/``.
+
 3.1.3 (2014-10-28)
 ------------------
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -48,3 +48,5 @@ Contributors
 - Márk Sági-Kazár, 2013-12-16
 
 - Gülşah Köse, 2014-07-17
+
+- Seyeong Jeong, 2016-03-19

--- a/TODO.txt
+++ b/TODO.txt
@@ -69,8 +69,6 @@
 
    - Option to automatically refresh the status page (issue #73).
 
-   - Better support for use with proxy servers (issue #29)
-
 - Expat error on Jens' system running slapd as root after reload.
 
 - Command-line arg tests.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -171,6 +171,18 @@ configuration values are as follows.
 
   *Introduced*: 3.0
 
+``base_path``
+
+  Specify the base path for the web interface. For example,
+  ``base_path=/supervisor/`` yields the web interface accessible at
+  ``http://localhost:4567/supervisor/``.
+
+  *Default*:  ``/``
+
+  *Required*:  No.
+
+  *Introduced*: 4.0
+
 ``[inet_http_server]`` Section Example
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -1025,6 +1025,15 @@ class ServerOptions(Options):
             config['host'] = host
             config['port'] = port
             config['section'] = section
+
+            # sanitize base_path
+            base_path = get(section, 'base_path', '/')
+            if not base_path.endswith('/'):
+                base_path += '/'
+            if not base_path.startswith('/'):
+                base_path = '/' + base_path
+            config['base_path'] = base_path
+
             configs.append(config)
 
         unix_serverdefs = self._parse_servernames(parser, 'unix_http_server')

--- a/supervisor/skel/sample.conf
+++ b/supervisor/skel/sample.conf
@@ -19,6 +19,7 @@ file=/tmp/supervisor.sock   ; (the path to the socket file)
 ;port=127.0.0.1:9001        ; (ip_address:port specifier, *:port for all iface)
 ;username=user              ; (default is no username (open server))
 ;password=123               ; (default is no password (open server))
+;base_path=/supervisor/     ; (default is /)
 
 [supervisord]
 logfile=/tmp/supervisord.log ; (main log file;default $CWD/supervisord.log)

--- a/supervisor/tests/base.py
+++ b/supervisor/tests/base.py
@@ -604,6 +604,7 @@ class DummyMedusaServerLogger:
 class DummyMedusaServer:
     def __init__(self):
         self.logger = DummyMedusaServerLogger()
+        self.base_path = '/'
 
 class DummyMedusaChannel:
     def __init__(self):

--- a/supervisor/ui/status.html
+++ b/supervisor/ui/status.html
@@ -6,6 +6,7 @@
   <title>Supervisor Status</title>
   <link href="stylesheets/supervisor.css" rel="stylesheet" type="text/css" />
   <link href="images/icon.png" rel="icon" type="image/png" />
+  <base meld:id="base_path" href="/" />
 </head>
 <body>
 <div id="wrapper">

--- a/supervisor/web.py
+++ b/supervisor/web.py
@@ -185,6 +185,10 @@ class MeldView:
         response['body'] = as_string(body)
         return response
 
+    @property
+    def base_path(self):
+        return self.context.request.channel.server.base_path
+
     def render(self):
         pass
 
@@ -429,9 +433,7 @@ class StatusView(MeldView):
                 if message is NOT_DONE_YET:
                     return NOT_DONE_YET
                 if message is not None:
-                    server_url = form['SERVER_URL']
-                    location = server_url + '?message=%s' % urllib.quote(
-                        message)
+                    location = '%s?message=%s' % (self.base_path, urllib.quote(message))
                     response['headers']['Location'] = location
 
         supervisord = self.context.supervisord
@@ -511,6 +513,7 @@ class StatusView(MeldView):
         root.findmeld('supervisor_version').content(VERSION)
         copyright_year = str(datetime.date.today().year)
         root.findmeld('copyright_date').content(copyright_year)
+        root.findmeld('base_path').attrib['href'] = self.base_path
 
         return as_string(root.write_xhtmlstring())
 
@@ -556,9 +559,7 @@ class supervisor_ui_handler:
         if not path:
             path = 'index.html'
 
-        for viewname in VIEWS.keys():
-            if viewname == path:
-                return True
+        return path in VIEWS.keys()
 
     def handle_request(self, request):
         if request.command == 'POST':


### PR DESCRIPTION
This is a pull request to resolve issue #29 and #372.
Instead of relying on `HTTP_REFERER` like in #28, I have introduced a new option.

This PR also addresses issue #495.