### PR TITLE
bdist_rpm: Use correct RPM name for meld3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ cover-erase=1
 
 [bdist_rpm]
 requires = 
-  meld3
+  python-meld3
 
 [aliases]
 dev = develop easy_install supervisor[testing]


### PR DESCRIPTION
The package on CentOS/Fedora/RHEL is "python-meld3", not just "meld3". This
commit fixes the name so the resultant RPM will be installable using
standard packages.