### PR TITLE
Avoid exception if time has drifted backward

### DIFF
--- a/supervisor/process.py
+++ b/supervisor/process.py
@@ -483,7 +483,7 @@ class Subprocess(object):
         self.laststop = now
         processname = self.config.name
 
-        tooquickly = now - self.laststart < self.config.startsecs
+        tooquickly = now - self.laststart < self.config.startsecs if now > self.laststart else False
         exit_expected = es in self.config.exitcodes
 
         if self.killing:


### PR DESCRIPTION
Hi, there is small workaround to prevent assertion for finished process, if for some reason current time is earlier than time when process was started.

In my case it's rather artificial condition - our QA team changes the current date back and forth trying to reproduce and/or find other issues. And sometimes they have run into this condition - when child process is exited normally, tooquicky becomes True and current process state doesn't match expected STARTING.