### PR TITLE
pidproxy: support for daemons which terminate immediately and do not provide a no-detach option

### DIFF
--- a/supervisor/pidproxy.py
+++ b/supervisor/pidproxy.py
@@ -21,7 +21,6 @@ class PidProxy:
         self.cmdargs = cmdargs
 
     def go(self):
-        print(self.cmdargs)
         self.pid = os.spawnv(os.P_NOWAIT, self.command, self.cmdargs)
         if self.wait_pidfile_time:
             self.wait_pidfile_showup()
@@ -40,6 +39,7 @@ class PidProxy:
     def wait_pidfile_showup(self):
         for i in range(self.wait_pidfile_time*10):
             time.sleep(0.1)
+            os.waitpid(-1, os.WNOHANG)
             if self.pid_exists():
                 return
         raise Exception("pid file %r failed to appear after %r seconds. Assuming the process died prematurely" % (

--- a/supervisor/pidproxy.py
+++ b/supervisor/pidproxy.py
@@ -7,22 +7,27 @@ import os
 import sys
 import signal
 import time
+import argparse
+
+
 
 class PidProxy:
-    pid = None
-    def __init__(self, args):
+    def __init__(self, pidfile, cmdargs, wait_pidfile_time=None):
         self.setsignals()
-        try:
-            self.pidfile, cmdargs = args[1], args[2:]
-            self.command = os.path.abspath(cmdargs[0])
-            self.cmdargs = cmdargs
-        except (ValueError, IndexError):
-            self.usage()
-            sys.exit(1)
+        self.wait_pidfile_time = wait_pidfile_time
+        self.pid = None
+        self.pidfile = pidfile
+        self.command = os.path.abspath(cmdargs[0])
+        self.cmdargs = cmdargs
 
     def go(self):
         self.pid = os.spawnv(os.P_NOWAIT, self.command, self.cmdargs)
-        while 1:
+        if self.wait_pidfile_time:
+            self.wait_pidfile_showup()
+            self.wait_pidfile_lifetime()
+            return
+
+        while True:
             time.sleep(5)
             try:
                 pid, sts = os.waitpid(-1, os.WNOHANG)
@@ -31,8 +36,17 @@ class PidProxy:
             if pid:
                 break
 
-    def usage(self):
-        print("pidproxy.py <pidfile name> <command> [<cmdarg1> ...]")
+    def wait_pidfile_showup(self):
+        for i in range(self.wait_pidfile_time*10):
+            time.sleep(0.1)
+            if self.pid_exists():
+                return
+        raise Exception("pid file %r failed to appear after %r seconds. Assuming the process died prematurely" % (
+            self.pidfile, self.wait_pidfile_time))
+
+    def wait_pidfile_lifetime(self):
+        while self.pid_exists():
+            time.sleep(5)
 
     def setsignals(self):
         signal.signal(signal.SIGTERM, self.passtochild)
@@ -49,8 +63,7 @@ class PidProxy:
 
     def passtochild(self, sig, frame):
         try:
-            with open(self.pidfile, 'r') as f:
-                pid = int(f.read().strip())
+            pid = self.get_pid()
         except:
             print("Can't read child pidfile %s!" % self.pidfile)
             return
@@ -58,8 +71,29 @@ class PidProxy:
         if sig in [signal.SIGTERM, signal.SIGINT, signal.SIGQUIT]:
             sys.exit(0)
 
+    def get_pid(self):
+        with open(self.pidfile, 'r') as f:
+            return int(f.read().strip())
+
+    def pid_exists(self):
+        try:
+            pid = self.get_pid()
+            os.kill(pid, 0)
+            return True
+        except (OSError, IOError):
+            return False
+
+
 def main():
-    pp = PidProxy(sys.argv)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("pidfile", help="pid file location")
+    parser.add_argument("command", help="command to run (with args)", nargs="+")
+    parser.add_argument("--wait", help="wait pid file creation for WAIT seconds, "
+                                       "then monitor the pid in order to track the process lifetime "
+                                       "(useful for processes which fork to background)",
+                        default=60, type=int)
+    params = parser.parse_args()
+    pp = PidProxy(pidfile=params.pidfile, cmdargs=params.command, wait_pidfile_time=params.wait)
     pp.go()
 
 if __name__ == '__main__':

--- a/supervisor/pidproxy.py
+++ b/supervisor/pidproxy.py
@@ -21,6 +21,7 @@ class PidProxy:
         self.cmdargs = cmdargs
 
     def go(self):
+        print(self.cmdargs)
         self.pid = os.spawnv(os.P_NOWAIT, self.command, self.cmdargs)
         if self.wait_pidfile_time:
             self.wait_pidfile_showup()
@@ -87,7 +88,7 @@ class PidProxy:
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("pidfile", help="pid file location")
-    parser.add_argument("command", help="command to run (with args)", nargs="+")
+    parser.add_argument("command", help="command to run (with args)", nargs=argparse.REMAINDER)
     parser.add_argument("--wait", help="wait pid file creation for WAIT seconds, "
                                        "then monitor the pid in order to track the process lifetime "
                                        "(useful for processes which fork to background)",


### PR DESCRIPTION
Daemon which do not expose a 'foreground' feature can now be handled via the
--wait parameter. Pidproxy will wait the specified amount of seconds for valid
pidfile to appear, then will monitor the pid in order to figure out if the proxied
process has died.
The pidfile must refer to an existing pid in order to be considered valid.