### PR TITLE
Make readFile filter control chars 0x1F and below, except for TAB, CR and LF.

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -1956,7 +1956,11 @@ class FastCGIGroupConfig(ProcessGroupConfig):
 
 def readFile(filename, offset, length):
     """ Read length bytes from the file named by filename starting at
-    offset """
+    offset
+
+    Filter control characters x0-x1f except for tab, cr and lf. They would
+    cause problems when marshalling later on.
+    """
 
     absoffset = abs(offset)
     abslength = abs(length)
@@ -1985,6 +1989,9 @@ def readFile(filename, offset, length):
                     data = f.read(length)
     except (OSError, IOError):
         raise ValueError('FAILED')
+
+    # Filter most control characters except tab, cr and lf.
+    data = ''.join(ch for ch in data if (ch >= ' ' or ch in '\n\r\t'))
 
     return data
 


### PR DESCRIPTION
This is needed because there might be control characters like ESC in
log files and xmlrpclib marshaller does not process them leading into
invalid XML.

You can typically run into this when processes output ansi colors. The esc sequences are passed as is and typically cause a crash in a xml-rpc client connecting to supervisord and requesting log files stdout or stderr. The control chars need to be either escaped or removed. Given this method is used for log files I propose filtering them.
