### PR TITLE
Improved python3 detection

### DIFF
--- a/supervisor/compat.py
+++ b/supervisor/compat.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import sys
-PY3 = sys.version>'3'
+PY3 = sys.version_info.major >= 3
 
 if PY3: # pragma: no cover
     long = int


### PR DESCRIPTION
compat.py now uses the version number stored in `sys.version_info`, rather than a string comparison, to check the python version.