### PR TITLE
Fix #369 relative command path (New)

### DIFF
--- a/supervisor/process.py
+++ b/supervisor/process.py
@@ -115,19 +115,18 @@ class Subprocess(object):
         else:
             raise BadCommand("command is empty")
 
-        if "/" in program:
-            if program.startswith('/'):
-                filename = program
-            else:
-                filename = os.path.join(self.config.directory, program)
-
+        if os.path.isabs(program):
+            filename = program
             try:
                 st = self.config.options.stat(filename)
             except OSError:
                 st = None
-
         else:
             path = self.config.options.get_path()
+            # Search the root config directory of this program if it's set and is absolute.
+            if self.config.directory is not None and os.path.isabs(self.config.directory):
+                path.insert(0, self.config.directory)
+
             found = None
             st = None
             for dir in path:


### PR DESCRIPTION
1. Uses isabs() for program check which was mentioned here as a desired fix and makes sense.
1. Inserts program directory into position 0 in path search for program, which is similar to how path search works in other programs when executing a command from a directory.
1. Now has two tests for having the program in a custom path, and for having the program in the program directory.

Incorporates feedback from original pull:
https://github.com/Supervisor/supervisor/pull/508

Resolves:
https://github.com/Supervisor/supervisor/issues/369

I would update the docs.  "If it is relative, the supervisord’s environment $PATH will be searched for the executable." => "If it is relative, the program's directory and supervisord’s environment $PATH will be searched for the executable."