### PR TITLE
Quit child processes when supervisor crashes (Linux only)

### DIFF
--- a/supervisor/process.py
+++ b/supervisor/process.py
@@ -1,4 +1,3 @@
-import platform
 import sys
 import os
 import time

--- a/supervisor/process.py
+++ b/supervisor/process.py
@@ -1,3 +1,5 @@
+import platform
+import sys
 import os
 import time
 import errno
@@ -297,14 +299,15 @@ class Subprocess(object):
             # Send this process a kill signal if supervisor crashes.
             # Uses system call prctl(PR_SET_PDEATHSIG, <signal>).
             # This will only work on Linux.
-            try:
-                import ctypes
-                import ctypes.util
-                libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library('c'))
-                libc.prctl(1, signal.SIGKILL)
-            except Exception, e:
-                options.logger.debug("Could not set parent death signal. "
-                                     "This is expected if not running on Linux.")
+            if sys.platform.startswith("linux"):
+                try:
+                    import ctypes
+                    import ctypes.util
+                    libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library('c'))
+                    PR_SET_PDEATHSIG = 1
+                    libc.prctl(PR_SET_PDEATHSIG, signal.SIGKILL)
+                except Exception:
+                    options.logger.debug("Could not set parent death signal.")
 
             self._prepare_child_fds()
             # sending to fd 2 will put this output in the stderr log

--- a/supervisor/process.py
+++ b/supervisor/process.py
@@ -26,9 +26,11 @@ from supervisor.dispatchers import EventListenerStates
 from supervisor import events
 
 from supervisor.datatypes import RestartUnconditionally
-from supervisor.datatypes import signal_number
 
 from supervisor.socket_manager import SocketManager
+
+# Constant from http://linux.die.net/include/linux/prctl.h
+PR_SET_PDEATHSIG = 1
 
 @total_ordering
 class Subprocess(object):
@@ -303,7 +305,6 @@ class Subprocess(object):
                     import ctypes
                     import ctypes.util
                     libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library('c'))
-                    PR_SET_PDEATHSIG = 1
                     libc.prctl(PR_SET_PDEATHSIG, signal.SIGKILL)
                 except Exception:
                     options.logger.debug("Could not set parent death signal.")

--- a/supervisor/tests/test_process.py
+++ b/supervisor/tests/test_process.py
@@ -639,10 +639,10 @@ class SubprocessTests(unittest.TestCase):
         # this is a functional test
         from supervisor.tests.base import makeSpew
         try:
-            called = 0
-            def foo(*args):
-                called = 1
-            signal.signal(signal.SIGCHLD, foo)
+            sigchlds = []
+            def sighandler(*args):
+                sigchlds.append(True)
+            signal.signal(signal.SIGCHLD, sighandler)
             executable = makeSpew()
             options = DummyOptions()
             config = DummyPConfig(options, 'spew', executable)
@@ -670,6 +670,7 @@ class SubprocessTests(unittest.TestCase):
             pid, sts = os.waitpid(-1, os.WNOHANG)
             data = os.popen('ps').read()
             self.assertEqual(data.find(as_bytes(repr(origpid))), -1) # dubious
+            self.assertNotEqual(sigchlds, [])
         finally:
             try:
                 os.remove(executable)


### PR DESCRIPTION
I'm just adding a check around only calling the code on a linux box and adding a constant so it's a little more clear. Would be cool to get this one finally out of the pull requests backlog.

Original pull request: https://github.com/Supervisor/supervisor/pull/199