### PR TITLE
Improve Medusa zombie connection detection

### DIFF
--- a/supervisor/medusa/CHANGES.txt
+++ b/supervisor/medusa/CHANGES.txt
@@ -4,6 +4,7 @@ PATCHES MADE ONLY TO THIS MEDUSA PACKAGE BUNDLED WITH SUPERVISOR
   of these modules introduced backward-incompatible changes.
 * Changed imports throughout from "medusa" to "supervisor.medusa".
 * Removed medusa files not used by Supervisor.
+* Time out connections based on inactivity instead of age
 
 Version 0.5.5:
 

--- a/supervisor/medusa/http_server.py
+++ b/supervisor/medusa/http_server.py
@@ -474,6 +474,7 @@ class http_channel (asynchat.async_chat):
         self.set_terminator ('\r\n\r\n')
         self.in_buffer = ''
         self.creation_time = int (time.time())
+        self.last_used = self.creation_time
         self.check_maintenance()
 
     def __repr__ (self):
@@ -501,7 +502,7 @@ class http_channel (asynchat.async_chat):
         now = int (time.time())
         for channel in asyncore.socket_map.values():
             if channel.__class__ == self.__class__:
-                if (now - channel.creation_time) > channel.zombie_timeout:
+                if (now - channel.last_used) > channel.zombie_timeout:
                     channel.close()
 
     # --------------------------------------------------
@@ -513,12 +514,14 @@ class http_channel (asynchat.async_chat):
     def send (self, data):
         result = asynchat.async_chat.send (self, data)
         self.server.bytes_out.increment (len(data))
+        self.last_used = int (time.time())
         return result
 
     def recv (self, buffer_size):
         try:
             result = asynchat.async_chat.recv (self, buffer_size)
             self.server.bytes_in.increment (len(result))
+            self.last_used = int (time.time())
             return result
         except MemoryError:
             # --- Save a Trip to Your Service Provider ---


### PR DESCRIPTION
Medusa checked every 500 connections made for connections older
than 30 minutes and closed them. This made it impossible to keep
a persistent connection when many short-lived connections happen at
the same time. It will now only close connections that have been
inactive for that amount of time, i.e. no send/recv activity.

Fixes #650