### PR TITLE
Added a "restartpause" option + fixing travis-checks

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -874,6 +874,7 @@ class ServerOptions(Options):
         autorestart = auto_restart(get(section, 'autorestart', 'unexpected'))
         startsecs = integer(get(section, 'startsecs', 1))
         startretries = integer(get(section, 'startretries', 3))
+        restartpause = integer(get(section, 'restartpause', 0))
         stopsignal = signal_number(get(section, 'stopsignal', 'TERM'))
         stopwaitsecs = integer(get(section, 'stopwaitsecs', 10))
         stopasgroup = boolean(get(section, 'stopasgroup', 'false'))
@@ -982,6 +983,7 @@ class ServerOptions(Options):
                 autorestart=autorestart,
                 startsecs=startsecs,
                 startretries=startretries,
+                restartpause=restartpause,
                 uid=uid,
                 stdout_logfile=logfiles['stdout_logfile'],
                 stdout_capture_maxbytes = stdout_cmaxbytes,
@@ -1783,7 +1785,7 @@ class Config(object):
 class ProcessConfig(Config):
     req_param_names = [
         'name', 'uid', 'command', 'directory', 'umask', 'priority',
-        'autostart', 'autorestart', 'startsecs', 'startretries',
+        'autostart', 'autorestart', 'startsecs', 'startretries', 'restartpause',
         'stdout_logfile', 'stdout_capture_maxbytes',
         'stdout_events_enabled', 'stdout_syslog',
         'stdout_logfile_backups', 'stdout_logfile_maxbytes',

--- a/supervisor/process.py
+++ b/supervisor/process.py
@@ -171,7 +171,7 @@ class Subprocess(object):
         if new_state == ProcessStates.BACKOFF:
             now = time.time()
             self.backoff += 1
-            self.delay = now + self.backoff
+            self.delay = now + self.backoff + self.config.restartpause
 
         self.state = new_state
 
@@ -544,6 +544,9 @@ class Subprocess(object):
                 # unexpected exit code
                 self.spawnerr = 'Bad exit code %s' % es
                 msg = "exited: %s (%s)" % (processname, msg + "; not expected")
+                self.delay = now + self.config.restartpause
+                if self.config.restartpause > 0: 
+                    msg += ". Will restart in %s seconds (restartpause)" % self.config.restartpause
                 self.change_state(ProcessStates.EXITED, expected=False)
 
         self.config.options.logger.info(msg)
@@ -593,7 +596,7 @@ class Subprocess(object):
         if self.config.options.mood > SupervisorStates.RESTARTING:
             # dont start any processes if supervisor is shutting down
             if state == ProcessStates.EXITED:
-                if self.config.autorestart:
+                if self.config.autorestart and now > self.delay:
                     if self.config.autorestart is RestartUnconditionally:
                         # EXITED -> STARTING
                         self.spawn()

--- a/supervisor/tests/base.py
+++ b/supervisor/tests/base.py
@@ -507,7 +507,7 @@ class DummyProcess(object):
 class DummyPConfig:
     def __init__(self, options, name, command, directory=None, umask=None,
                  priority=999, autostart=True,
-                 autorestart=True, startsecs=10, startretries=999,
+                 autorestart=True, startsecs=10, startretries=999, restartpause=2,
                  uid=None, stdout_logfile=None, stdout_capture_maxbytes=0,
                  stdout_events_enabled=False,
                  stdout_logfile_backups=0, stdout_logfile_maxbytes=0,
@@ -525,6 +525,7 @@ class DummyPConfig:
         self.autorestart = autorestart
         self.startsecs = startsecs
         self.startretries = startretries
+        self.restartpause = restartpause
         self.uid = uid
         self.stdout_logfile = stdout_logfile
         self.stdout_capture_maxbytes = stdout_capture_maxbytes

--- a/supervisor/tests/test_options.py
+++ b/supervisor/tests/test_options.py
@@ -436,6 +436,7 @@ class ServerOptionsTests(unittest.TestCase):
         stopwaitsecs=5
         startsecs=5
         startretries=10
+        restartpause=2
         directory=/tmp
         umask=002
 
@@ -516,6 +517,7 @@ class ServerOptionsTests(unittest.TestCase):
         self.assertEqual(proc1.autorestart, datatypes.RestartWhenExitUnexpected)
         self.assertEqual(proc1.startsecs, 5)
         self.assertEqual(proc1.startretries, 10)
+        self.assertEqual(proc1.restartpause, 2)
         self.assertEqual(proc1.uid, 0)
         self.assertEqual(proc1.stdout_logfile, '/tmp/cat.log')
         self.assertEqual(proc1.stopsignal, signal.SIGKILL)
@@ -1369,6 +1371,7 @@ class ServerOptionsTests(unittest.TestCase):
         autorestart = false
         startsecs = 100
         startretries = 100
+        restartpause = 2
         user = root
         stdout_logfile = NONE
         stdout_logfile_backups = 1
@@ -1395,6 +1398,7 @@ class ServerOptionsTests(unittest.TestCase):
         self.assertEqual(pconfig.autorestart, False)
         self.assertEqual(pconfig.startsecs, 100)
         self.assertEqual(pconfig.startretries, 100)
+        self.assertEqual(pconfig.restartpause, 2)
         self.assertEqual(pconfig.uid, 0)
         self.assertEqual(pconfig.stdout_logfile, None)
         self.assertEqual(pconfig.stdout_capture_maxbytes, 0)
@@ -1557,6 +1561,7 @@ class ServerOptionsTests(unittest.TestCase):
         stopwaitsecs=%(ENV_CAT1_STOPWAIT)s
         startsecs=%(ENV_CAT1_STARTWAIT)s
         startretries=%(ENV_CAT1_STARTRETRIES)s
+        restartpause=%(ENV_CAT1_RESTARTPAUSE)s
         directory=%(ENV_CAT1_DIR)s
         umask=%(ENV_CAT1_UMASK)s
         """)
@@ -1590,6 +1595,7 @@ class ServerOptionsTests(unittest.TestCase):
             'ENV_CAT1_STOPWAIT': '5',
             'ENV_CAT1_STARTWAIT': '5',
             'ENV_CAT1_STARTRETRIES': '10',
+            'ENV_CAT1_RESTARTPAUSE': '2',
             'ENV_CAT1_DIR': '/tmp',
             'ENV_CAT1_UMASK': '002',
            }
@@ -1634,6 +1640,7 @@ class ServerOptionsTests(unittest.TestCase):
         self.assertEqual(proc1.autorestart, datatypes.RestartWhenExitUnexpected)
         self.assertEqual(proc1.startsecs, 5)
         self.assertEqual(proc1.startretries, 10)
+        self.assertEqual(proc1.restartpause, 2)
         self.assertEqual(proc1.uid, 0)
         self.assertEqual(proc1.stdout_logfile, '/tmp/cat.log')
         self.assertEqual(proc1.stopsignal, signal.SIGKILL)
@@ -2670,7 +2677,7 @@ class TestProcessConfig(unittest.TestCase):
         defaults = {}
         for name in ('name', 'command', 'directory', 'umask',
                      'priority', 'autostart', 'autorestart',
-                     'startsecs', 'startretries', 'uid',
+                     'startsecs', 'startretries', 'restartpause' ,'uid',
                      'stdout_logfile', 'stdout_capture_maxbytes',
                      'stdout_events_enabled', 'stdout_syslog',
                      'stderr_logfile', 'stderr_capture_maxbytes',
@@ -2752,7 +2759,7 @@ class EventListenerConfigTests(unittest.TestCase):
         defaults = {}
         for name in ('name', 'command', 'directory', 'umask',
                      'priority', 'autostart', 'autorestart',
-                     'startsecs', 'startretries', 'uid',
+                     'startsecs', 'startretries', 'restartpause' ,'uid',
                      'stdout_logfile', 'stdout_capture_maxbytes',
                      'stdout_events_enabled', 'stdout_syslog',
                      'stderr_logfile', 'stderr_capture_maxbytes',
@@ -2800,7 +2807,7 @@ class FastCGIProcessConfigTest(unittest.TestCase):
         defaults = {}
         for name in ('name', 'command', 'directory', 'umask',
                      'priority', 'autostart', 'autorestart',
-                     'startsecs', 'startretries', 'uid',
+                     'startsecs', 'startretries', 'restartpause', 'uid',
                      'stdout_logfile', 'stdout_capture_maxbytes',
                      'stdout_events_enabled', 'stdout_syslog',
                      'stderr_logfile', 'stderr_capture_maxbytes',

--- a/supervisor/tests/test_supervisord.py
+++ b/supervisor/tests/test_supervisord.py
@@ -318,7 +318,7 @@ class SupervisordTests(unittest.TestCase):
             result = {
                 'name': name, 'command': command,
                 'directory': None, 'umask': None, 'priority': 999, 'autostart': True,
-                'autorestart': True, 'startsecs': 10, 'startretries': 999,
+                'autorestart': True, 'startsecs': 10, 'startretries': 999, 'restartpause': 2,
                 'uid': None, 'stdout_logfile': None, 'stdout_capture_maxbytes': 0,
                 'stdout_events_enabled': False,
                 'stdout_logfile_backups': 0, 'stdout_logfile_maxbytes': 0,


### PR DESCRIPTION
This is actually the same as PR #509 by fclairamb, just added my 2 cents, and (hopefully) fixed the tests. Please let us know if there's anything more needed to get this merged.


Thanks
---
* Applied on startup failure aditionnaly to the backoff delay (by fclairamb)
* Applied on bad exit status (by fclairamb)
* fixed tests (by pfuender)

Default value is 0, which doesn't change the existing behavior.

The goal is to impose a minimum delay between restarts to avoid overloading host with restarts.