### PR TITLE
Fix xmlrpclib typo

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -945,7 +945,7 @@
 - A new module "supervisor.childutils" was added.  This module
   provides utilities for Python scripts which act as children of
   supervisord.  Most notably, it contains an API method
-  "getRPCInterface" allows you to obtain an xmlrpxlib ServerProxy
+  "getRPCInterface" allows you to obtain an xmlrpclib ServerProxy
   that is willing to communicate with the parent supervisor.  It
   also contains utility functions that allow for parsing of
   supervisor event listener protocol headers.  A pair of scripts


### PR DESCRIPTION
Fix a little typo: `xmlrpxlib` => `xmlrpclib`