### PR TITLE
Expose "xmlrpc" command in supervisorctl

### DIFF
--- a/supervisor/supervisorctl.py
+++ b/supervisor/supervisorctl.py
@@ -25,6 +25,8 @@ actions.
 import cmd
 import sys
 import getpass
+import json
+import shlex
 
 import socket
 import errno
@@ -1004,6 +1006,20 @@ class DefaultControllerPlugin(ControllerPluginBase):
         else:
             for pinfo in configinfo:
                 self.ctl.output(self._formatConfigInfo(pinfo))
+
+    def do_xmlrpc(self, arg):
+        server_proxy = self.ctl.get_server_proxy()
+        if arg:
+            args = shlex.split(arg)
+            method = getattr(server_proxy, args[0])
+            data = method(*args[1:])
+
+            try:
+                self.ctl.output(data)
+            except TypeError:
+                self.ctl.output(json.dumps(data, indent=4))
+        else:
+            self.ctl.output('\n'.join(server_proxy.system.listMethods()))
 
     def help_avail(self):
         self.ctl.output("avail\t\t\tDisplay all configured processes")


### PR DESCRIPTION
I'm using this to introspect the supervisord xmlrpc interface and thought this could be generally useful. E.g.:

    $ supervisorctl xmlrpc
    supervisor.addProcessGroup
    supervisor.clearAllProcessLogs
    supervisor.clearLog
    supervisor.clearProcessLog
    supervisor.clearProcessLogs
    supervisor.getAPIVersion
    supervisor.getAllConfigInfo
    supervisor.getAllProcessInfo
    ...

    $ supervisorctl xmlrpc system.methodHelp supervisor.getAllProcessInfo
     Get info about all processes

            @return array result  An array of process status results

    $ supervisorctl xmlrpc supervisor.getAllProcessInfo
    [
        {
            "now": 1444234763,
            "group": "cat",
            "description": "pid 91863, uptime 1:06:50",
            "pid": 91863,
            "stderr_logfile": "/Users/marca/dev/git-repos/supervisor/var/log/supervisor/0-stderr---supervisor-orzRzC.log",
            "stop": 0,
            "statename": "RUNNING",
            "start": 1444230753,
            "state": 20,
            "stdout_logfile": "/Users/marca/dev/git-repos/supervisor/var/log/supervisor/0-stdout---supervisor-hpyJxf.log",
            "logfile": "/Users/marca/dev/git-repos/supervisor/var/log/supervisor/0-stdout---supervisor-hpyJxf.log",
            "exitstatus": 0,
            "spawnerr": "",
            "name": "0"
        },
        ...

     $ supervisorctl xmlrpc supervisor.getProcessInfo sleep_and_die
     {
         "now": 1444235418,
         "group": "sleep_and_die",
         "description": "Exited too quickly (process log may have details)",
         "pid": 0,
         "stderr_logfile": "/Users/marca/dev/git-repos/supervisor/var/log/supervisor/sleep_and_die-stderr---supervisor-dgrwh6.log",
         "stop": 1444231035,
         "statename": "FATAL",
         "start": 1444231030,
         "state": 200,
         "stdout_logfile": "/Users/marca/dev/git-repos/supervisor/var/log/supervisor/sleep_and_die-stdout---supervisor-YmRdkF.log",
         "logfile": "/Users/marca/dev/git-repos/supervisor/var/log/supervisor/sleep_and_die-stdout---supervisor-YmRdkF.log",
         "exitstatus": 0,
         "spawnerr": "Exited too quickly (process log may have details)",
         "name": "sleep_and_die"
     }