### PR TITLE
Add LSB Exit codes for non-interactive mode.

### DIFF
--- a/docs/running.rst
+++ b/docs/running.rst
@@ -217,8 +217,10 @@ The :command:`supervisorctl` executable may be invoked with "one time"
 commands when invoked with arguments from a command line.  An example:
 ``supervisorctl stop all``.  If arguments are present on the
 command-line, it will prevent the interactive shell from being
-invoked.  Instead, the command will be executed and
-``supervisorctl`` will exit.
+invoked.  Instead, the command will be executed and ``supervisorctl``
+will exit with a code of 0 for success or running and non-zero for
+error. An example: ``supervisorctl status all`` would return non-zero
+if any single process was not running.
 
 If :command:`supervisorctl` is invoked in interactive mode against a
 :program:`supervisord` that requires authentication, you will be asked

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -1579,6 +1579,7 @@ class ClientOptions(Options):
     username = None
     password = None
     history_file = None
+    exit_on_error = None
 
     def __init__(self):
         Options.__init__(self, require_configfile=False)
@@ -1590,6 +1591,9 @@ class ClientOptions(Options):
         self.configroot.supervisorctl.username = None
         self.configroot.supervisorctl.password = None
         self.configroot.supervisorctl.history_file = None
+
+        # Set to 0 because it's only activated in realize() if not in interactive mode.
+        self.configroot.supervisorctl.exit_on_error = 0
 
         from supervisor.supervisorctl import DefaultControllerPlugin
         default_factory = ('default', DefaultControllerPlugin, {})
@@ -1610,6 +1614,8 @@ class ClientOptions(Options):
         Options.realize(self, *arg, **kw)
         if not self.args:
             self.interactive = 1
+
+        self.exit_on_error = 0 if self.interactive else 1
 
     def read_config(self, fp):
         section = self.configroot.supervisorctl

--- a/supervisor/supervisorctl.py
+++ b/supervisor/supervisorctl.py
@@ -759,7 +759,7 @@ class DefaultControllerPlugin(ControllerPluginBase):
         supervisor = self.ctl.get_supervisor()
 
         if not names:
-            self.handle_error("Error: start requires a process name")
+            self.handle_error("Error: start requires a process name", code=LSBInitErrorCode.INVALID_ARGS)
             self.help_start()
             return
 
@@ -778,9 +778,9 @@ class DefaultControllerPlugin(ControllerPluginBase):
                     except xmlrpclib.Fault as e:
                         if e.faultCode == xmlrpc.Faults.BAD_NAME:
                             error = "%s: ERROR (no such group)" % group_name
-                            self.ctl.handle_error(error)
+                            self.handle_error(error, code=LSBInitErrorCode.INVALID_ARGS)
                         else:
-                            self.ctl.handle_error(fatal=True)
+                            self.handle_error(fatal=True)
                 else:
                     try:
                         result = supervisor.startProcess(name)

--- a/supervisor/supervisorctl.py
+++ b/supervisor/supervisorctl.py
@@ -44,6 +44,21 @@ from supervisor import xmlrpc
 from supervisor import states
 from supervisor import http_client
 
+class LSBInitErrorCode:
+    GENERIC = 1
+    INVALID_ARGS = 2
+    UNIMPLEMENTED_FEATURE = 3
+    INSUFFICIENT_PRIVLEDGES = 4
+    NOT_INSTALLED = 5
+    NOT_CONFIGURED = 6
+    NOT_RUNNING = 7
+
+class LSBStatusErrorCode:
+    DEAD_WITH_PID = 1
+    DEAD_WITH_LOCK = 2
+    NOT_RUNNING = 3
+    UNKNOWN = 4
+
 class fgthread(threading.Thread):
     """ A subclass of threading.Thread, with a kill() method.
     To be used for foreground output/error streaming.
@@ -91,7 +106,7 @@ class fgthread(threading.Thread):
     def localtrace(self, frame, why, arg):
         if self.killed:
             if why == 'line':
-                raise SystemExit()
+                sys.exit(0)
         return self.localtrace
 
     def kill(self):
@@ -108,6 +123,7 @@ class Controller(cmd.Cmd):
         self.options.plugins = []
         self.vocab = ['help']
         self._complete_info = None
+        self.exit_status = None
         cmd.Cmd.__init__(self, completekey, stdin, stdout)
         for name, factory, kwargs in self.options.plugin_factories:
             plugin = factory(self, **kwargs)
@@ -120,6 +136,10 @@ class Controller(cmd.Cmd):
     def emptyline(self):
         # We don't want a blank line to repeat the last command.
         return
+
+    def default(self, line):
+        super(Controller, self).default(line)
+        self.handle_error()
 
     def exec_cmdloop(self, args, options):
         try:
@@ -153,12 +173,38 @@ class Controller(cmd.Cmd):
             self.output('')
             pass
 
+    def handle_xmlrpc_fault_state(self, state_handler, result, ignore_state=None):
+        code = result['status']
+        result = state_handler(result)
+        if code == ignore_state or code == xmlrpc.Faults.SUCCESS:
+            self.output(result)
+        elif code in xmlrpc.DEAD_PROGRAM_FAULTS:
+            self.handle_error(message=result, code=LSBInitErrorCode.NOT_RUNNING)
+        else:
+            self.handle_error(message=result)
+
+    def handle_error(self, message=None, fatal=False, code=None):
+        if code is None:
+            code = LSBInitErrorCode.GENERIC
+        if message:
+            self.output(message)
+        if self.exit_status is None:
+            self.exit_status = code
+        if fatal:
+            raise
+
     def onecmd(self, line):
         """ Override the onecmd method to:
           - catch and print all exceptions
           - allow for composite commands in interactive mode (foo; bar)
           - call 'do_foo' on plugins rather than ourself
         """
+        result = self.onecmd_run(line)
+        if self.options.exit_on_error and self.exit_status is not None:
+            raise SystemExit(self.exit_status)
+        return result
+
+    def onecmd_run(self, line):
         origline = line
         lines = line.split(';') # don't filter(None, line.split), as we pop
         line = lines.pop(0)
@@ -172,6 +218,7 @@ class Controller(cmd.Cmd):
             return self.default(line)
         self._complete_info = None
         self.lastcmd = line
+
         if cmd == '':
             return self.default(line)
         else:
@@ -190,20 +237,16 @@ class Controller(cmd.Cmd):
                             self.output('')
                             self.options.username = username
                             self.options.password = password
-                            return self.onecmd(origline)
+                            return self.onecmd_run(origline)
                         else:
-                            self.options.usage('Server requires authentication')
+                            self.handle_error('Server requires authentication')
                     else:
-                        raise
+                        self.handle_error(fatal=True)
                 do_func(arg)
-            except SystemExit:
-                raise
             except Exception:
                 (file, fun, line), t, v, tbinfo = asyncore.compact_traceback()
                 error = 'error: %s, %s: file: %s line: %s' % (t, v, file, line)
-                self.output(error)
-                if not self.options.interactive:
-                    sys.exit(2)
+                self.handle_error(error)
 
     def _get_do_func(self, cmd):
         func_name = 'do_' + cmd
@@ -237,29 +280,29 @@ class Controller(cmd.Cmd):
             api = supervisor.getVersion() # deprecated
             from supervisor import rpcinterface
             if api != rpcinterface.API_VERSION:
-                self.output(
+                self.handle_error(
                     'Sorry, this version of supervisorctl expects to '
                     'talk to a server with API version %s, but the '
-                    'remote version is %s.' % (rpcinterface.API_VERSION, api))
+                    'remote version is %s.' % (rpcinterface.API_VERSION, api), code=LSBInitErrorCode.NOT_INSTALLED)
                 return False
         except xmlrpclib.Fault as e:
             if e.faultCode == xmlrpc.Faults.UNKNOWN_METHOD:
-                self.output(
+                self.handle_error(
                     'Sorry, supervisord responded but did not recognize '
                     'the supervisor namespace commands that supervisorctl '
                     'uses to control it.  Please check that the '
                     '[rpcinterface:supervisor] section is enabled in the '
-                    'configuration file (see sample.conf).')
+                    'configuration file (see sample.conf).', code=LSBInitErrorCode.UNIMPLEMENTED_FEATURE)
                 return False
-            raise
-        except socket.error as why:
-            if why.args[0] == errno.ECONNREFUSED:
-                self.output('%s refused connection' % self.options.serverurl)
+            self.handle_error(fatal=True)
+        except socket.error as e:
+            if e.args[0] == errno.ECONNREFUSED:
+                self.handle_error(message='%s refused connection' % self.options.serverurl, code=LSBInitErrorCode.INSUFFICIENT_PRIVLEDGES)
                 return False
-            elif why.args[0] == errno.ENOENT:
-                self.output('%s no such file' % self.options.serverurl)
+            elif e.args[0] == errno.ENOENT:
+                self.handle_error(message='%s no such file' % self.options.serverurl, code=LSBInitErrorCode.NOT_RUNNING)
                 return False
-            raise
+            self.handle_error(fatal=True)
         return True
 
     def complete(self, text, state, line=None):
@@ -447,12 +490,12 @@ class DefaultControllerPlugin(ControllerPluginBase):
         args = arg.split()
 
         if len(args) < 1:
-            self.ctl.output('Error: too few arguments')
+            self.handle_error('Error: too few arguments')
             self.help_tail()
             return
 
         elif len(args) > 3:
-            self.ctl.output('Error: too many arguments')
+            self.handle_error('Error: too many arguments')
             self.help_tail()
             return
 
@@ -469,10 +512,10 @@ class DefaultControllerPlugin(ControllerPluginBase):
                 name = args[0]
                 channel = args[-1].lower()
                 if channel not in ('stderr', 'stdout'):
-                    self.ctl.output('Error: bad channel %r' % channel)
+                    self.handle_error('Error: bad channel %r' % channel)
                     return
             else:
-                self.ctl.output('Error: tail requires process name')
+                self.handle_error('Error: tail requires process name')
                 return
 
         bytes = 1600
@@ -485,7 +528,7 @@ class DefaultControllerPlugin(ControllerPluginBase):
                 try:
                     bytes = int(what)
                 except:
-                    self.ctl.output('Error: bad argument %s' % modifier)
+                    self.handle_error('Error: bad argument %s' % modifier)
                     return
 
         supervisor = self.ctl.get_supervisor()
@@ -504,15 +547,15 @@ class DefaultControllerPlugin(ControllerPluginBase):
             except xmlrpclib.Fault as e:
                 template = '%s: ERROR (%s)'
                 if e.faultCode == xmlrpc.Faults.NO_FILE:
-                    self.ctl.output(template % (name, 'no log file'))
+                    self.handle_error(template % (name, 'no log file'))
                 elif e.faultCode == xmlrpc.Faults.FAILED:
-                    self.ctl.output(template % (name,
-                                             'unknown error reading log'))
+                    self.handle_error(template % (name,
+                                      'unknown error reading log'))
                 elif e.faultCode == xmlrpc.Faults.BAD_NAME:
-                    self.ctl.output(template % (name,
-                                             'no such process name'))
+                    self.handle_error(template % (name,
+                                      'no such process name'))
                 else:
-                    raise
+                    self.handle_error(fatal=True)
             else:
                 self.ctl.output(output)
 
@@ -533,7 +576,7 @@ class DefaultControllerPlugin(ControllerPluginBase):
         args = arg.split()
 
         if len(args) > 1:
-            self.ctl.output('Error: too many arguments')
+            self.handle_error('Error: too many arguments')
             self.help_maintail()
             return
 
@@ -546,12 +589,12 @@ class DefaultControllerPlugin(ControllerPluginBase):
                 try:
                     what = int(what)
                 except:
-                    self.ctl.output('Error: bad argument %s' % args[0])
+                    self.handle_error('Error: bad argument %s' % args[0])
                     return
                 else:
                     bytes = what
             else:
-                self.ctl.output('Error: bad argument %s' % args[0])
+                self.handle_error('Error: bad argument %s' % args[0])
                 return
 
         else:
@@ -564,12 +607,12 @@ class DefaultControllerPlugin(ControllerPluginBase):
         except xmlrpclib.Fault as e:
             template = '%s: ERROR (%s)'
             if e.faultCode == xmlrpc.Faults.NO_FILE:
-                self.ctl.output(template % ('supervisord', 'no log file'))
+                self.handle_error(template % ('supervisord', 'no log file'))
             elif e.faultCode == xmlrpc.Faults.FAILED:
-                self.ctl.output(template % ('supervisord',
-                                         'unknown error reading log'))
+                self.handle_error(template % ('supervisord',
+                                              'unknown error reading log'))
             else:
-                raise
+                self.handle_error(fatal=True)
         else:
             self.ctl.output(output)
 
@@ -606,8 +649,13 @@ class DefaultControllerPlugin(ControllerPluginBase):
                                'desc': info['description']}
             self.ctl.output(line)
 
-    def do_status(self, arg):
+    def do_status(self, arg, supress_exit_status=False):
+        """In case upcheck sets an error_status we sanitize it for do_status call which should only return 4
+        for this case."""
+        exit_status = self.ctl.exit_status
         if not self.ctl.upcheck():
+            if exit_status is not None:
+                self.ctl.exit_status = LSBStatusErrorCode.UNKNOWN
             return
 
         supervisor = self.ctl.get_supervisor()
@@ -618,7 +666,6 @@ class DefaultControllerPlugin(ControllerPluginBase):
             matching_infos = all_infos
         else:
             matching_infos = []
-
             for name in names:
                 bad_name = True
                 group_name, process_name = split_namespec(name)
@@ -637,8 +684,14 @@ class DefaultControllerPlugin(ControllerPluginBase):
                         msg = "%s: ERROR (no such group)" % group_name
                     else:
                         msg = "%s: ERROR (no such process)" % name
-                    self.ctl.output(msg)
+                    self.ctl.handle_error(msg, code=LSBStatusErrorCode.UNKNOWN)
         self._show_statuses(matching_infos)
+
+        # Special case where we consider a status call that contains a stopped status to be an error.
+        if not supress_exit_status:
+            for info in matching_infos:
+                if info['state'] in states.STOPPED_STATES:
+                    self.ctl.handle_error(code=LSBStatusErrorCode.NOT_RUNNING)
 
     def help_status(self):
         self.ctl.output("status <name>\t\tGet status for a single process")
@@ -665,9 +718,9 @@ class DefaultControllerPlugin(ControllerPluginBase):
                     info = supervisor.getProcessInfo(name)
                 except xmlrpclib.Fault as e:
                     if e.faultCode == xmlrpc.Faults.BAD_NAME:
-                        self.ctl.output('No such process %s' % name)
+                        self.ctl.handle_error('No such process %s' % name)
                     else:
-                        raise
+                        self.ctl.handle_error(fatal=True)
                 else:
                     self.ctl.output(str(info['pid']))
 
@@ -702,21 +755,18 @@ class DefaultControllerPlugin(ControllerPluginBase):
     def do_start(self, arg):
         if not self.ctl.upcheck():
             return
-
         names = arg.split()
         supervisor = self.ctl.get_supervisor()
 
         if not names:
-            self.ctl.output("Error: start requires a process name")
+            self.handle_error("Error: start requires a process name")
             self.help_start()
             return
 
         if 'all' in names:
             results = supervisor.startAllProcesses()
             for result in results:
-                result = self._startresult(result)
-                self.ctl.output(result)
-
+                self.ctl.handle_xmlrpc_fault_state(self._startresult, result, xmlrpc.Faults.ALREADY_STARTED)
         else:
             for name in names:
                 group_name, process_name = split_namespec(name)
@@ -724,23 +774,22 @@ class DefaultControllerPlugin(ControllerPluginBase):
                     try:
                         results = supervisor.startProcessGroup(group_name)
                         for result in results:
-                            result = self._startresult(result)
-                            self.ctl.output(result)
+                            self.ctl.handle_xmlrpc_fault_state(self._startresult, result, xmlrpc.Faults.ALREADY_STARTED)
                     except xmlrpclib.Fault as e:
                         if e.faultCode == xmlrpc.Faults.BAD_NAME:
                             error = "%s: ERROR (no such group)" % group_name
-                            self.ctl.output(error)
+                            self.ctl.handle_error(error)
                         else:
-                            raise
+                            self.ctl.handle_error(fatal=True)
                 else:
                     try:
                         result = supervisor.startProcess(name)
                     except xmlrpclib.Fault as e:
-                        error = self._startresult({'status': e.faultCode,
-                                                   'name': process_name,
-                                                   'group': group_name,
-                                                   'description': e.faultString})
-                        self.ctl.output(error)
+                        error = {'status': e.faultCode,
+                                  'name': process_name,
+                                  'group': group_name,
+                                  'description': e.faultString}
+                        self.ctl.handle_xmlrpc_fault_state(self._startresult, error, xmlrpc.Faults.ALREADY_STARTED)
                     else:
                         name = make_namespec(group_name, process_name)
                         self.ctl.output('%s: started' % name)
@@ -776,45 +825,42 @@ class DefaultControllerPlugin(ControllerPluginBase):
     def do_stop(self, arg):
         if not self.ctl.upcheck():
             return
-
         names = arg.split()
         supervisor = self.ctl.get_supervisor()
 
         if not names:
-            self.ctl.output('Error: stop requires a process name')
+            self.handle_error('Error: stop requires a process name')
             self.help_stop()
             return
 
         if 'all' in names:
             results = supervisor.stopAllProcesses()
             for result in results:
-                result = self._stopresult(result)
-                self.ctl.output(result)
-
+                self.ctl.handle_xmlrpc_fault_state(self._stopresult, result, xmlrpc.Faults.NOT_RUNNING)
         else:
             for name in names:
                 group_name, process_name = split_namespec(name)
                 if process_name is None:
                     try:
                         results = supervisor.stopProcessGroup(group_name)
+
                         for result in results:
-                            result = self._stopresult(result)
-                            self.ctl.output(result)
+                            self.ctl.handle_xmlrpc_fault_state(self._stopresult, result, xmlrpc.Faults.NOT_RUNNING)
                     except xmlrpclib.Fault as e:
                         if e.faultCode == xmlrpc.Faults.BAD_NAME:
                             error = "%s: ERROR (no such group)" % group_name
-                            self.ctl.output(error)
+                            self.ctl.handle_error(message=error)
                         else:
-                            raise
+                            self.ctl.handle_error(fatal=True)
                 else:
                     try:
                         supervisor.stopProcess(name)
                     except xmlrpclib.Fault as e:
-                        error = self._stopresult({'status': e.faultCode,
-                                                  'name': process_name,
-                                                  'group': group_name,
-                                                  'description':e.faultString})
-                        self.ctl.output(error)
+                        error = {'status': e.faultCode,
+                                 'name': process_name,
+                                 'group': group_name,
+                                 'description':e.faultString}
+                        self.ctl.handle_xmlrpc_fault_state(self._stopresult, error, xmlrpc.Faults.NOT_RUNNING)
                     else:
                         name = make_namespec(group_name, process_name)
                         self.ctl.output('%s: stopped' % name)
@@ -834,6 +880,7 @@ class DefaultControllerPlugin(ControllerPluginBase):
             self.ctl.output(
                 'Error: signal requires a signal name and a process name')
             self.help_signal()
+            self.handle_error()
             return
 
         sig = args[0]
@@ -842,10 +889,9 @@ class DefaultControllerPlugin(ControllerPluginBase):
 
         if 'all' in names:
             results = supervisor.signalAllProcesses(sig)
-            for result in results:
-                result = self._signalresult(result)
-                self.ctl.output(result)
 
+            for result in results:
+                self.ctl.handle_xmlrpc_fault_state(self._signalresult, result)
         else:
             for name in names:
                 group_name, process_name = split_namespec(name)
@@ -855,23 +901,22 @@ class DefaultControllerPlugin(ControllerPluginBase):
                             group_name, sig
                             )
                         for result in results:
-                            result = self._signalresult(result)
-                            self.ctl.output(result)
+                            self.ctl.handle_xmlrpc_fault_state(self._signalresult, result)
                     except xmlrpclib.Fault as e:
                         if e.faultCode == xmlrpc.Faults.BAD_NAME:
                             error = "%s: ERROR (no such group)" % group_name
-                            self.ctl.output(error)
+                            self.ctl.handle_error(error)
                         else:
                             raise
                 else:
                     try:
                         supervisor.signalProcess(name, sig)
                     except xmlrpclib.Fault as e:
-                        error = self._signalresult({'status': e.faultCode,
-                                                    'name': process_name,
-                                                    'group': group_name,
-                                                    'description':e.faultString})
-                        self.ctl.output(error)
+                        error = {'status': e.faultCode,
+                                 'name': process_name,
+                                 'group': group_name,
+                                 'description':e.faultString}
+                        self.ctl.handle_xmlrpc_fault_state(self._signalresult, error)
                     else:
                         name = make_namespec(group_name, process_name)
                         self.ctl.output('%s: signalled' % name)
@@ -889,7 +934,7 @@ class DefaultControllerPlugin(ControllerPluginBase):
         names = arg.split()
 
         if not names:
-            self.ctl.output('Error: restart requires a process name')
+            self.handle_error('Error: restart requires a process name')
             self.help_restart()
             return
 
@@ -921,16 +966,16 @@ class DefaultControllerPlugin(ControllerPluginBase):
                 if e.faultCode == xmlrpc.Faults.SHUTDOWN_STATE:
                     self.ctl.output('ERROR: already shutting down')
                 else:
-                    raise
+                    self.handle_error(fatal=True)
             except socket.error as e:
                 if e.args[0] == errno.ECONNREFUSED:
                     msg = 'ERROR: %s refused connection (already shut down?)'
-                    self.ctl.output(msg % self.ctl.options.serverurl)
+                    self.handle_error(msg % self.ctl.options.serverurl)
                 elif e.args[0] == errno.ENOENT:
                     msg = 'ERROR: %s no such file (already shut down?)'
-                    self.ctl.output(msg % self.ctl.options.serverurl)
+                    self.handle_error(msg % self.ctl.options.serverurl)
                 else:
-                    raise
+                    self.handle_error(fatal=True)
             else:
                 self.ctl.output('Shut down')
 
@@ -950,9 +995,9 @@ class DefaultControllerPlugin(ControllerPluginBase):
                 supervisor.restart()
             except xmlrpclib.Fault as e:
                 if e.faultCode == xmlrpc.Faults.SHUTDOWN_STATE:
-                    self.ctl.output('ERROR: already shutting down')
+                    self.handle_error('ERROR: already shutting down')
                 else:
-                    raise
+                    self.handle_error(fatal=True)
             else:
                 self.ctl.output('Restarted supervisord')
 
@@ -998,9 +1043,9 @@ class DefaultControllerPlugin(ControllerPluginBase):
             configinfo = supervisor.getAllConfigInfo()
         except xmlrpclib.Fault as e:
             if e.faultCode == xmlrpc.Faults.SHUTDOWN_STATE:
-                self.ctl.output('ERROR: supervisor shutting down')
+                self.handle_error('ERROR: supervisor shutting down')
             else:
-                raise
+                self.handle_error(fatal=True)
         else:
             for pinfo in configinfo:
                 self.ctl.output(self._formatConfigInfo(pinfo))
@@ -1014,13 +1059,16 @@ class DefaultControllerPlugin(ControllerPluginBase):
             result = supervisor.reloadConfig()
         except xmlrpclib.Fault as e:
             if e.faultCode == xmlrpc.Faults.SHUTDOWN_STATE:
-                self.ctl.output('ERROR: supervisor shutting down')
+                self.handle_error('ERROR: supervisor shutting down')
             elif e.faultCode == xmlrpc.Faults.CANT_REREAD:
-                self.ctl.output('ERROR: %s' % e.faultString)
+                self.handle_error("ERROR: %s" % e.faultString)
             else:
-                raise
+                self.handle_error(fatal=True)
         else:
             self._formatChanges(result[0])
+
+    def handle_error(self, message=None, fatal=False, code=None):
+        self.ctl.handle_error(message=message, fatal=fatal, code=code)
 
     def help_reread(self):
         self.ctl.output("reread \t\t\tReload the daemon's configuration files")
@@ -1034,14 +1082,13 @@ class DefaultControllerPlugin(ControllerPluginBase):
                 supervisor.addProcessGroup(name)
             except xmlrpclib.Fault as e:
                 if e.faultCode == xmlrpc.Faults.SHUTDOWN_STATE:
-                    self.ctl.output('ERROR: shutting down')
+                    self.handle_error('ERROR: shutting down')
                 elif e.faultCode == xmlrpc.Faults.ALREADY_ADDED:
                     self.ctl.output('ERROR: process group already active')
                 elif e.faultCode == xmlrpc.Faults.BAD_NAME:
-                    self.ctl.output(
-                        "ERROR: no such process/group: %s" % name)
+                    self.handle_error("ERROR: no such process/group: %s" % name)
                 else:
-                    raise
+                    self.handle_error(fatal=True)
             else:
                 self.ctl.output("%s: added process group" % name)
 
@@ -1058,13 +1105,12 @@ class DefaultControllerPlugin(ControllerPluginBase):
                 supervisor.removeProcessGroup(name)
             except xmlrpclib.Fault as e:
                 if e.faultCode == xmlrpc.Faults.STILL_RUNNING:
-                    self.ctl.output('ERROR: process/group still running: %s'
-                                    % name)
+                    self.handle_error('ERROR: process/group still running: %s'
+                                      % name)
                 elif e.faultCode == xmlrpc.Faults.BAD_NAME:
-                    self.ctl.output(
-                        "ERROR: no such process/group: %s" % name)
+                    self.handle_error("ERROR: no such process/group: %s" % name)
                 else:
-                    raise
+                    self.handle_error(fatal=True)
             else:
                 self.ctl.output("%s: removed process group" % name)
 
@@ -1081,10 +1127,10 @@ class DefaultControllerPlugin(ControllerPluginBase):
             result = supervisor.reloadConfig()
         except xmlrpclib.Fault as e:
             if e.faultCode == xmlrpc.Faults.SHUTDOWN_STATE:
-                self.ctl.output('ERROR: already shutting down')
+                self.handle_error('ERROR: already shutting down')
                 return
             else:
-                raise
+                self.handle_error(fatal=True)
 
         added, changed, removed = result[0]
         valid_gnames = set(arg.split())
@@ -1105,7 +1151,7 @@ class DefaultControllerPlugin(ControllerPluginBase):
 
             for gname in valid_gnames:
                 if gname not in groups:
-                    self.ctl.output('ERROR: no such group: %s' % gname)
+                    self.ctl.handle_error('ERROR: no such group: %s' % gname)
 
         for gname in removed:
             if valid_gnames and gname not in valid_gnames:
@@ -1116,7 +1162,7 @@ class DefaultControllerPlugin(ControllerPluginBase):
             fails = [res for res in results
                      if res['status'] == xmlrpc.Faults.FAILED]
             if fails:
-                log(gname, "has problems; not removing")
+                self.ctl.handle_error("%s: %s" % (gname, "has problems; not removing"))
                 continue
             supervisor.removeProcessGroup(gname)
             log(gname, "removed process group")
@@ -1161,7 +1207,7 @@ class DefaultControllerPlugin(ControllerPluginBase):
         names = arg.split()
 
         if not names:
-            self.ctl.output('Error: clear requires a process name')
+            self.handle_error('Error: clear requires a process name')
             self.help_clear()
             return
 
@@ -1170,19 +1216,18 @@ class DefaultControllerPlugin(ControllerPluginBase):
         if 'all' in names:
             results = supervisor.clearAllProcessLogs()
             for result in results:
-                result = self._clearresult(result)
-                self.ctl.output(result)
+                self.ctl.handle_xmlrpc_fault_state(self._clearresult, result)
         else:
             for name in names:
                 group_name, process_name = split_namespec(name)
                 try:
                     supervisor.clearProcessLogs(name)
                 except xmlrpclib.Fault as e:
-                    error = self._clearresult({'status': e.faultCode,
-                                               'name': process_name,
-                                               'group': group_name,
-                                               'description': e.faultString})
-                    self.ctl.output(error)
+                    error = {'status': e.faultCode,
+                             'name': process_name,
+                             'group': group_name,
+                             'description': e.faultString}
+                    self.ctl.handle_xmlrpc_fault_state(self._clearresult, error)
                 else:
                     name = make_namespec(group_name, process_name)
                     self.ctl.output('%s: cleared' % name)
@@ -1197,10 +1242,10 @@ class DefaultControllerPlugin(ControllerPluginBase):
         url = arg.strip()
         parts = urlparse.urlparse(url)
         if parts[0] not in ('unix', 'http'):
-            self.ctl.output('ERROR: url must be http:// or unix://')
+            self.handle_error('ERROR: url must be http:// or unix://')
             return
         self.ctl.options.serverurl = url
-        self.do_status('')
+        self.do_status('', True)
 
     def help_open(self):
         self.ctl.output("open <url>\tConnect to a remote supervisord process.")
@@ -1221,12 +1266,12 @@ class DefaultControllerPlugin(ControllerPluginBase):
         if not self.ctl.upcheck():
             return
         if not args:
-            self.ctl.output('Error: no process name supplied')
+            self.handle_error('Error: no process name supplied')
             self.help_fg()
             return
         args = args.split()
         if len(args) > 1:
-            self.ctl.output('Error: too many process names supplied')
+            self.handle_error('Error: too many process names supplied')
             return
         program = args[0]
         supervisor = self.ctl.get_supervisor()
@@ -1234,13 +1279,13 @@ class DefaultControllerPlugin(ControllerPluginBase):
             info = supervisor.getProcessInfo(program)
         except xmlrpclib.Fault as msg:
             if msg.faultCode == xmlrpc.Faults.BAD_NAME:
-                self.ctl.output('Error: bad process name supplied')
+                self.handle_error('Error: bad process name supplied')
                 return
             # for any other fault
             self.ctl.output(str(msg))
             return
         if not info['state'] == states.ProcessStates.RUNNING:
-            self.ctl.output('Error: process not running')
+            self.handle_error('Error: process not running')
             return
         # everything good; continue
         a = None

--- a/supervisor/tests/test_supervisorctl.py
+++ b/supervisor/tests/test_supervisorctl.py
@@ -781,7 +781,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         expected = "Error: start requires a process name"
         self.assertEqual(plugin.ctl.stdout.getvalue().split('\n')[0], expected)
-        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.INVALID_ARGS)
 
     def test_start_badname(self):
         plugin = self._makeOne()
@@ -870,7 +870,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'BAD_NAME: ERROR (no such group)\n')
-        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.INVALID_ARGS)
 
     def test_start_all(self):
         plugin = self._makeOne()

--- a/supervisor/tests/test_supervisorctl.py
+++ b/supervisor/tests/test_supervisorctl.py
@@ -1,7 +1,9 @@
 import sys
 import unittest
+from supervisor import xmlrpc
 from supervisor.compat import StringIO
 from supervisor.compat import xmlrpclib
+from supervisor.supervisorctl import LSBInitErrorCode, LSBStatusErrorCode
 from supervisor.tests.base import DummyRPCServer
 
 class fgthread_Tests(unittest.TestCase):
@@ -37,7 +39,12 @@ class fgthread_Tests(unittest.TestCase):
         ctl = DummyController(options)
         inst = self._makeOne(None, ctl)
         inst.killed = True
-        self.assertRaises(SystemExit, inst.localtrace, None, 'line', None)
+        try:
+            inst.localtrace(None, 'line', None)
+        except SystemExit as e:
+            self.assertEqual(e.code, 0)
+        else:
+            self.fail("No exception thrown. Excepted SystemExit")
 
     def test_localtrace_killed_not_whyline(self):
         options = DummyClientOptions()
@@ -69,6 +76,7 @@ class ControllerTests(unittest.TestCase):
 
     def _makeOne(self, options):
         return self._getTargetClass()(options)
+
 
     def test_ctor(self):
         options = DummyClientOptions()
@@ -120,6 +128,7 @@ class ControllerTests(unittest.TestCase):
         controller = self._makeOne(options)
         controller.stdout = StringIO()
         self.assertRaises(xmlrpclib.Fault, controller.upcheck)
+        self.assertEqual(controller.exit_status, LSBInitErrorCode.GENERIC)
 
     def test__upcheck_catches_socket_error_ECONNREFUSED(self):
         options = DummyClientOptions()
@@ -137,6 +146,7 @@ class ControllerTests(unittest.TestCase):
 
         output = controller.stdout.getvalue()
         self.assertTrue('refused connection' in output)
+        self.assertEqual(controller.exit_status, LSBInitErrorCode.INSUFFICIENT_PRIVLEDGES)
 
     def test__upcheck_catches_socket_error_ENOENT(self):
         options = DummyClientOptions()
@@ -154,6 +164,7 @@ class ControllerTests(unittest.TestCase):
 
         output = controller.stdout.getvalue()
         self.assertTrue('no such file' in output)
+        self.assertEqual(controller.exit_status, LSBInitErrorCode.NOT_RUNNING)
 
     def test__upcheck_reraises_other_socket_faults(self):
         options = DummyClientOptions()
@@ -207,6 +218,16 @@ class ControllerTests(unittest.TestCase):
         controller._complete_info = {}
         controller.onecmd('help')
         self.assertEqual(controller._complete_info, None)
+
+    def test_onecmd_exit_with_code(self):
+        expected_code = 99
+        options = DummyClientOptions()
+        options.exit_on_error = True
+        controller = self._makeOne(options)
+        controller.stdout = StringIO()
+        controller.exit_status = expected_code
+        self.assertRaises(SystemExit, controller.onecmd, "")
+        self.assertEqual(controller.exit_status, expected_code)
 
     def test_complete_action_empty(self):
         options = DummyClientOptions()
@@ -491,6 +512,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         lines = plugin.ctl.stdout.getvalue().split('\n')
         self.assertEqual(lines[0], 'Error: too few arguments')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_tail_toomanyargs(self):
         plugin = self._makeOne()
@@ -498,6 +520,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         lines = plugin.ctl.stdout.getvalue().split('\n')
         self.assertEqual(lines[0], 'Error: too many arguments')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_tail_f_noprocname(self):
         plugin = self._makeOne()
@@ -505,6 +528,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         lines = plugin.ctl.stdout.getvalue().split('\n')
         self.assertEqual(lines[0], 'Error: tail requires process name')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_tail_bad_modifier(self):
         plugin = self._makeOne()
@@ -512,6 +536,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         lines = plugin.ctl.stdout.getvalue().split('\n')
         self.assertEqual(lines[0], 'Error: bad argument -z')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_tail_defaults(self):
         plugin = self._makeOne()
@@ -528,6 +553,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         lines = plugin.ctl.stdout.getvalue().split('\n')
         self.assertEqual(len(lines), 2)
         self.assertEqual(lines[0], 'NO_FILE: ERROR (no log file)')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_tail_failed(self):
         plugin = self._makeOne()
@@ -536,6 +562,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         lines = plugin.ctl.stdout.getvalue().split('\n')
         self.assertEqual(len(lines), 2)
         self.assertEqual(lines[0], 'FAILED: ERROR (unknown error reading log)')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_tail_bad_name(self):
         plugin = self._makeOne()
@@ -544,6 +571,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         lines = plugin.ctl.stdout.getvalue().split('\n')
         self.assertEqual(len(lines), 2)
         self.assertEqual(lines[0], 'BAD_NAME: ERROR (no such process name)')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_tail_bytesmodifier(self):
         plugin = self._makeOne()
@@ -575,6 +603,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         value = plugin.ctl.stdout.getvalue().strip()
         self.assertEqual(value, "Error: bad channel 'fudge'")
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_tail_upcheck_failed(self):
         plugin = self._makeOne()
@@ -653,6 +682,25 @@ class TestDefaultControllerPlugin(unittest.TestCase):
                          ['bar', 'FATAL', 'bar description'])
         self.assertEqual(value[2].split(None, 2),
                          ['baz:baz_01', 'STOPPED', 'baz description'])
+        self.assertEqual(plugin.ctl.exit_status, LSBStatusErrorCode.NOT_RUNNING)
+
+
+    def test_status_success(self):
+        plugin = self._makeOne()
+        result = plugin.do_status('foo')
+        self.assertEqual(result, None)
+        self.assertEqual(plugin.ctl.exit_status, None)
+        value = plugin.ctl.stdout.getvalue().split('\n')
+        self.assertEqual(value[0].split(None, 2),
+                         ['foo', 'RUNNING', 'foo description'])
+
+    def test_status_unknown_process(self):
+        plugin = self._makeOne()
+        result = plugin.do_status('unknownprogram')
+        self.assertEqual(result, None)
+        value = plugin.ctl.stdout.getvalue()
+        self.assertEqual("unknownprogram: ERROR (no such process)\n", value)
+        self.assertEqual(plugin.ctl.exit_status, LSBStatusErrorCode.UNKNOWN)
 
     def test_status_all_processes_all_arg(self):
         plugin = self._makeOne()
@@ -665,6 +713,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
                          ['bar', 'FATAL', 'bar description'])
         self.assertEqual(value[2].split(None, 2),
                          ['baz:baz_01', 'STOPPED', 'baz description'])
+        self.assertEqual(plugin.ctl.exit_status, LSBStatusErrorCode.NOT_RUNNING)
 
     def test_status_process_name(self):
         plugin = self._makeOne()
@@ -673,6 +722,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         value = plugin.ctl.stdout.getvalue().strip()
         self.assertEqual(value.split(None, 2),
                          ['foo', 'RUNNING', 'foo description'])
+        self.assertEqual(plugin.ctl.exit_status, None)
 
     def test_status_group_name(self):
         plugin = self._makeOne()
@@ -681,6 +731,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         value = plugin.ctl.stdout.getvalue().split('\n')
         self.assertEqual(value[0].split(None, 2),
                          ['baz:baz_01', 'STOPPED', 'baz description'])
+        self.assertEqual(plugin.ctl.exit_status, LSBStatusErrorCode.NOT_RUNNING)
 
     def test_status_mixed_names(self):
         plugin = self._makeOne()
@@ -691,6 +742,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
                          ['foo', 'RUNNING', 'foo description'])
         self.assertEqual(value[1].split(None, 2),
                          ['baz:baz_01', 'STOPPED', 'baz description'])
+        self.assertEqual(plugin.ctl.exit_status, LSBStatusErrorCode.NOT_RUNNING)
 
     def test_status_bad_group_name(self):
         plugin = self._makeOne()
@@ -698,6 +750,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         value = plugin.ctl.stdout.getvalue().split('\n')
         self.assertEqual(value[0], "badgroup: ERROR (no such group)")
+        self.assertEqual(plugin.ctl.exit_status, LSBStatusErrorCode.UNKNOWN)
 
     def test_status_bad_process_name(self):
         plugin = self._makeOne()
@@ -705,6 +758,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         value = plugin.ctl.stdout.getvalue().split('\n')
         self.assertEqual(value[0], "badprocess: ERROR (no such process)")
+        self.assertEqual(plugin.ctl.exit_status, LSBStatusErrorCode.UNKNOWN)
 
     def test_status_bad_process_name_with_group(self):
         plugin = self._makeOne()
@@ -713,6 +767,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         value = plugin.ctl.stdout.getvalue().split('\n')
         self.assertEqual(value[0], "badgroup:badprocess: "
                                    "ERROR (no such process)")
+        self.assertEqual(plugin.ctl.exit_status, LSBStatusErrorCode.UNKNOWN)
 
     def test_start_help(self):
         plugin = self._makeOne()
@@ -726,6 +781,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         expected = "Error: start requires a process name"
         self.assertEqual(plugin.ctl.stdout.getvalue().split('\n')[0], expected)
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_start_badname(self):
         plugin = self._makeOne()
@@ -733,6 +789,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'BAD_NAME: ERROR (no such process)\n')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_start_no_file(self):
         plugin = self._makeOne()
@@ -740,6 +797,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'NO_FILE: ERROR (no such file)\n')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_start_not_executable(self):
         plugin = self._makeOne()
@@ -747,6 +805,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'NOT_EXECUTABLE: ERROR (file is not executable)\n')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_start_alreadystarted(self):
         plugin = self._makeOne()
@@ -754,6 +813,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'ALREADY_STARTED: ERROR (already started)\n')
+        self.assertEqual(plugin.ctl.exit_status, None)
 
     def test_start_spawnerror(self):
         plugin = self._makeOne()
@@ -761,6 +821,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'SPAWN_ERROR: ERROR (spawn error)\n')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.NOT_RUNNING)
 
     def test_start_abnormaltermination(self):
         plugin = self._makeOne()
@@ -768,6 +829,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         expected = 'ABNORMAL_TERMINATION: ERROR (abnormal termination)\n'
         self.assertEqual(plugin.ctl.stdout.getvalue(), expected)
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.NOT_RUNNING)
 
     def test_start_one_success(self):
         plugin = self._makeOne()
@@ -782,6 +844,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'foo: started\n')
+        self.assertEqual(plugin.ctl.exit_status, None)
 
     def test_start_many(self):
         plugin = self._makeOne()
@@ -789,6 +852,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'foo: started\nbar: started\n')
+        self.assertEqual(plugin.ctl.exit_status, None)
 
     def test_start_group(self):
         plugin = self._makeOne()
@@ -797,6 +861,8 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'foo:foo_00: started\n'
                          'foo:foo_01: started\n')
+        self.assertEqual(plugin.ctl.exit_status, None)
+
 
     def test_start_group_bad_name(self):
         plugin = self._makeOne()
@@ -804,6 +870,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'BAD_NAME: ERROR (no such group)\n')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_start_all(self):
         plugin = self._makeOne()
@@ -814,6 +881,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
                          'foo: started\n'
                          'foo2: started\n'
                          'failed_group:failed: ERROR (spawn error)\n')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.NOT_RUNNING)
 
     def test_start_upcheck_failed(self):
         plugin = self._makeOne()
@@ -839,6 +907,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue().split('\n')[0],
                          "Error: stop requires a process name")
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_stop_badname(self):
         plugin = self._makeOne()
@@ -846,6 +915,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'BAD_NAME: ERROR (no such process)\n')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_stop_notrunning(self):
         plugin = self._makeOne()
@@ -853,12 +923,14 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'NOT_RUNNING: ERROR (not running)\n')
+        self.assertEqual(plugin.ctl.exit_status, None)
 
     def test_stop_failed(self):
         plugin = self._makeOne()
         result = plugin.do_stop('FAILED')
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(), 'FAILED\n')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_stop_one_success(self):
         plugin = self._makeOne()
@@ -866,6 +938,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'foo: stopped\n')
+        self.assertEqual(plugin.ctl.exit_status, None)
 
     def test_stop_one_with_group_name_success(self):
         plugin = self._makeOne()
@@ -873,6 +946,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'foo: stopped\n')
+        self.assertEqual(plugin.ctl.exit_status, None)
 
     def test_stop_many(self):
         plugin = self._makeOne()
@@ -881,6 +955,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'foo: stopped\n'
                          'bar: stopped\n')
+        self.assertEqual(plugin.ctl.exit_status, None)
 
     def test_stop_group(self):
         plugin = self._makeOne()
@@ -889,6 +964,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'foo:foo_00: stopped\n'
                          'foo:foo_01: stopped\n')
+        self.assertEqual(plugin.ctl.exit_status, None)
 
     def test_stop_group_bad_name(self):
         plugin = self._makeOne()
@@ -896,6 +972,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'BAD_NAME: ERROR (no such group)\n')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_stop_all(self):
         plugin = self._makeOne()
@@ -905,6 +982,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
                          'foo: stopped\n'
                          'foo2: stopped\n'
                          'failed_group:failed: ERROR (no such process)\n')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_stop_upcheck_failed(self):
         plugin = self._makeOne()
@@ -930,6 +1008,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         msg = 'Error: signal requires a signal name and a process name'
         self.assertEqual(plugin.ctl.stdout.getvalue().split('\n')[0], msg)
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_signal_fail_one_arg(self):
         plugin = self._makeOne()
@@ -937,6 +1016,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         msg = 'Error: signal requires a signal name and a process name'
         self.assertEqual(plugin.ctl.stdout.getvalue().split('\n')[0], msg)
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_signal_bad_signal(self):
         plugin = self._makeOne()
@@ -944,6 +1024,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'foo: ERROR (bad signal name)\n')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_signal_bad_name(self):
         plugin = self._makeOne()
@@ -951,6 +1032,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'BAD_NAME: ERROR (no such process)\n')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_signal_bad_group(self):
         plugin = self._makeOne()
@@ -958,6 +1040,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'BAD_NAME: ERROR (no such group)\n')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_signal_not_running(self):
         plugin = self._makeOne()
@@ -965,18 +1048,21 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'NOT_RUNNING: ERROR (not running)\n')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.NOT_RUNNING)
 
     def test_signal_failed(self):
         plugin = self._makeOne()
         result = plugin.do_signal('HUP FAILED')
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(), 'FAILED\n')
+        self.assertEqual(plugin.ctl.exit_status, 1)
 
     def test_signal_one_success(self):
         plugin = self._makeOne()
         result = plugin.do_signal('HUP foo')
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(), 'foo: signalled\n')
+        self.assertEqual(plugin.ctl.exit_status, None)
 
     def test_signal_many(self):
         plugin = self._makeOne()
@@ -985,6 +1071,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'foo: signalled\n'
                          'bar: signalled\n')
+        self.assertEqual(plugin.ctl.exit_status, None)
 
     def test_signal_group(self):
         plugin = self._makeOne()
@@ -993,6 +1080,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'foo:foo_00: signalled\n'
                          'foo:foo_01: signalled\n')
+        self.assertEqual(plugin.ctl.exit_status, None)
 
     def test_signal_all(self):
         plugin = self._makeOne()
@@ -1002,6 +1090,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
                          'foo: signalled\n'
                          'foo2: signalled\n'
                          'failed_group:failed: ERROR (no such process)\n')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_signal_upcheck_failed(self):
         plugin = self._makeOne()
@@ -1027,6 +1116,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue().split('\n')[0],
                          'Error: restart requires a process name')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_restart_one(self):
         plugin = self._makeOne()
@@ -1034,6 +1124,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'foo: stopped\nfoo: started\n')
+        self.assertEqual(plugin.ctl.exit_status, None)
 
     def test_restart_all(self):
         plugin = self._makeOne()
@@ -1044,6 +1135,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
                          'failed_group:failed: ERROR (no such process)\n'
                          'foo: started\nfoo2: started\n'
                          'failed_group:failed: ERROR (spawn error)\n')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_restart_upcheck_failed(self):
         plugin = self._makeOne()
@@ -1069,6 +1161,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue().split('\n')[0],
                          "Error: clear requires a process name")
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_clear_badname(self):
         plugin = self._makeOne()
@@ -1076,6 +1169,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'BAD_NAME: ERROR (no such process)\n')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_clear_one_success(self):
         plugin = self._makeOne()
@@ -1083,6 +1177,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'foo: cleared\n')
+        self.assertEqual(plugin.ctl.exit_status, None)
 
     def test_clear_one_with_group_success(self):
         plugin = self._makeOne()
@@ -1090,6 +1185,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'foo: cleared\n')
+        self.assertEqual(plugin.ctl.exit_status, None)
 
     def test_clear_many(self):
         plugin = self._makeOne()
@@ -1097,6 +1193,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'foo: cleared\nbar: cleared\n')
+        self.assertEqual(plugin.ctl.exit_status, None)
 
     def test_clear_all(self):
         plugin = self._makeOne()
@@ -1107,6 +1204,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
                          'foo: cleared\n'
                          'foo2: cleared\n'
                          'failed_group:failed: ERROR (failed)\n')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_clear_upcheck_failed(self):
         plugin = self._makeOne()
@@ -1132,6 +1230,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'ERROR: url must be http:// or unix://\n')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_open_succeed(self):
         plugin = self._makeOne()
@@ -1144,6 +1243,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
                          ['bar', 'FATAL', 'bar description'])
         self.assertEqual(value[2].split(None, 2),
                          ['baz:baz_01', 'STOPPED', 'baz description'])
+        self.assertEqual(plugin.ctl.exit_status, None)
 
     def test_version_help(self):
         plugin = self._makeOne()
@@ -1212,6 +1312,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'ERROR: already shutting down\n')
+        self.assertEqual(plugin.ctl.exit_status, None)
 
     def test_shutdown_reraises_other_xmlrpc_faults(self):
         plugin = self._makeOne()
@@ -1223,6 +1324,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
 
         self.assertRaises(xmlrpclib.Fault,
                           plugin.do_shutdown, '')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_shutdown_catches_socket_error_ECONNREFUSED(self):
         plugin = self._makeOne()
@@ -1238,6 +1340,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
 
         output = plugin.ctl.stdout.getvalue()
         self.assertTrue('refused connection (already shut down?)' in output)
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_shutdown_catches_socket_error_ENOENT(self):
         plugin = self._makeOne()
@@ -1253,6 +1356,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
 
         output = plugin.ctl.stdout.getvalue()
         self.assertTrue('no such file (already shut down?)' in output)
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_shutdown_reraises_other_socket_errors(self):
         plugin = self._makeOne()
@@ -1265,6 +1369,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
 
         self.assertRaises(socket.error,
                           plugin.do_shutdown, '')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test__formatChanges(self):
         plugin = self._makeOne()
@@ -1277,6 +1382,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         plugin.help_reread()
         out = plugin.ctl.stdout.getvalue()
         self.assertTrue("Reload the daemon's configuration files" in out)
+        self.assertEqual(plugin.ctl.exit_status, None)
 
     def test_reread(self):
         plugin = self._makeOne()
@@ -1285,6 +1391,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         result = plugin.do_reread(None)
         self.assertEqual(result, None)
         self.assertEqual(calls[0], [['added'], ['changed'], ['removed']])
+        self.assertEqual(plugin.ctl.exit_status, None)
 
     def test_reread_cant_reread(self):
         plugin = self._makeOne()
@@ -1295,6 +1402,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         plugin.do_reread(None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'ERROR: cant\n')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_reread_shutdown_state(self):
         plugin = self._makeOne()
@@ -1305,6 +1413,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         plugin.do_reread(None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'ERROR: supervisor shutting down\n')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_reread_reraises_other_faults(self):
         plugin = self._makeOne()
@@ -1313,6 +1422,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
             raise xmlrpclib.Fault(xmlrpc.Faults.FAILED, '')
         plugin.ctl.options._server.supervisor.reloadConfig = reloadConfig
         self.assertRaises(xmlrpclib.Fault, plugin.do_reread, '')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test__formatConfigInfo(self):
         info = { 'group': 'group1',
@@ -1367,6 +1477,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'ERROR: supervisor shutting down\n')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_avail_reraises_other_faults(self):
         plugin = self._makeOne()
@@ -1378,6 +1489,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         supervisor.getAllConfigInfo = getAllConfigInfo
 
         self.assertRaises(xmlrpclib.Fault, plugin.do_avail, '')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_add_help(self):
         plugin = self._makeOne()
@@ -1391,6 +1503,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         supervisor = plugin.ctl.options._server.supervisor
         self.assertEqual(supervisor.processes, ['foo'])
+        self.assertEqual(plugin.ctl.exit_status, None)
 
     def test_add_already_added(self):
         plugin = self._makeOne()
@@ -1398,6 +1511,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'ERROR: process group already active\n')
+        self.assertEqual(plugin.ctl.exit_status, None)
 
     def test_add_bad_name(self):
         plugin = self._makeOne()
@@ -1405,6 +1519,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'ERROR: no such process/group: BAD_NAME\n')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_add_shutdown_state(self):
         plugin = self._makeOne()
@@ -1412,16 +1527,19 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'ERROR: shutting down\n')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_add_reraises_other_faults(self):
         plugin = self._makeOne()
         self.assertRaises(xmlrpclib.Fault, plugin.do_add, 'FAILED')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_remove_help(self):
         plugin = self._makeOne()
         plugin.help_remove()
         out = plugin.ctl.stdout.getvalue()
         self.assertTrue("remove <name>" in out)
+        self.assertEqual(plugin.ctl.exit_status, None)
 
     def test_remove(self):
         plugin = self._makeOne()
@@ -1439,6 +1557,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'ERROR: no such process/group: BAD_NAME\n')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_remove_still_running(self):
         plugin = self._makeOne()
@@ -1448,10 +1567,12 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'ERROR: process/group still running: STILL_RUNNING\n')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_remove_reraises_other_faults(self):
         plugin = self._makeOne()
         self.assertRaises(xmlrpclib.Fault, plugin.do_remove, 'FAILED')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_update_help(self):
         plugin = self._makeOne()
@@ -1618,6 +1739,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         supervisor.reloadConfig = reloadConfig
 
         self.assertRaises(xmlrpclib.Fault, plugin.do_update, '')
+        self.assertEqual(plugin.ctl.exit_status, 1)
 
     def test_pid_help(self):
         plugin = self._makeOne()
@@ -1640,6 +1762,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         value = plugin.ctl.stdout.getvalue().strip()
         self.assertEqual(value.split(), ['11', '12', '13'])
+        self.assertEqual(plugin.ctl.exit_status, None)
 
     def test_pid_badname(self):
         plugin = self._makeOne()
@@ -1647,12 +1770,14 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         value = plugin.ctl.stdout.getvalue().strip()
         self.assertEqual(value, 'No such process BAD_NAME')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_pid_oneprocess(self):
         plugin = self._makeOne()
         result = plugin.do_pid('foo')
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue().strip(), '11')
+        self.assertEqual(plugin.ctl.exit_status, None)
 
     def test_pid_upcheck_failed(self):
         plugin = self._makeOne()
@@ -1676,6 +1801,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         val = plugin.ctl.stdout.getvalue()
         self.assertTrue(val.startswith('Error: too many'), val)
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_maintail_minus_string_fails(self):
         plugin = self._makeOne()
@@ -1683,6 +1809,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         val = plugin.ctl.stdout.getvalue()
         self.assertTrue(val.startswith('Error: bad argument -wrong'), val)
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_maintail_wrong(self):
         plugin = self._makeOne()
@@ -1690,6 +1817,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         val = plugin.ctl.stdout.getvalue()
         self.assertTrue(val.startswith('Error: bad argument wrong'), val)
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_maintail_dashf(self):
         plugin = self._makeOne()
@@ -1711,6 +1839,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         lines = plugin.ctl.stdout.getvalue().split('\n')
         self.assertEqual(lines[0], 'Error: bad argument -z')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_maintail_nobytes(self):
         plugin = self._makeOne()
@@ -1733,6 +1862,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'supervisord: ERROR (no log file)\n')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_maintail_readlog_error_failed(self):
         plugin = self._makeOne()
@@ -1743,6 +1873,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         self.assertEqual(plugin.ctl.stdout.getvalue(),
                          'supervisord: ERROR (unknown error reading log)\n')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_maintail_upcheck_failed(self):
         plugin = self._makeOne()
@@ -1766,6 +1897,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         lines = plugin.ctl.stdout.getvalue().split('\n')
         self.assertEqual(lines[0], 'Error: no process name supplied')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_fg_too_many_args(self):
         plugin = self._makeOne()
@@ -1773,6 +1905,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         line = plugin.ctl.stdout.getvalue()
         self.assertEqual(line, 'Error: too many process names supplied\n')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_fg_badprocname(self):
         plugin = self._makeOne()
@@ -1780,6 +1913,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         self.assertEqual(result, None)
         line = plugin.ctl.stdout.getvalue()
         self.assertEqual(line, 'Error: bad process name supplied\n')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_fg_procnotrunning(self):
         plugin = self._makeOne()
@@ -1791,6 +1925,7 @@ class TestDefaultControllerPlugin(unittest.TestCase):
         lines = plugin.ctl.stdout.getvalue().split('\n')
         self.assertEqual(result, None)
         self.assertEqual(lines[-2], 'Error: process not running')
+        self.assertEqual(plugin.ctl.exit_status, LSBInitErrorCode.GENERIC)
 
     def test_fg_upcheck_failed(self):
         plugin = self._makeOne()
@@ -1839,6 +1974,7 @@ class DummyClientOptions:
         self.plugins = ()
         self._server = DummyRPCServer()
         self.interactive = False
+        self.exit_on_error = False
         self.plugin_factories = [('dummy', DummyPluginFactory, {})]
 
     def getServerProxy(self):
@@ -1850,6 +1986,7 @@ class DummyController:
         self.options = options
         self.topics_printed = []
         self.stdout = StringIO()
+        self.exit_status = None
 
     def upcheck(self):
         return True
@@ -1869,6 +2006,26 @@ class DummyController:
 
     def print_topics(self, doc_headers, cmds_doc, rows, cols):
         self.topics_printed.append((doc_headers, cmds_doc, rows, cols))
+
+    def handle_xmlrpc_fault_state(self, state_handler, result, ignore_state=None):
+        code = result['status']
+        result = state_handler(result)
+        if code == ignore_state or code == xmlrpc.Faults.SUCCESS:
+            self.output(result)
+        elif code in xmlrpc.DEAD_PROGRAM_FAULTS:
+            self.handle_error(message=result, code=LSBInitErrorCode.NOT_RUNNING)
+        else:
+            self.handle_error(message=result)
+
+    def handle_error(self, message=None, fatal=False, code=None):
+        if code is None:
+            code = LSBInitErrorCode.GENERIC
+        if message:
+            self.output(message)
+        if self.exit_status is None:
+            self.exit_status = code
+        if fatal:
+            raise
 
 class DummyPlugin:
     def __init__(self, controller=None):

--- a/supervisor/xmlrpc.py
+++ b/supervisor/xmlrpc.py
@@ -44,6 +44,10 @@ class Faults:
     STILL_RUNNING = 91
     CANT_REREAD = 92
 
+DEAD_PROGRAM_FAULTS = (Faults.SPAWN_ERROR,
+                       Faults.ABNORMAL_TERMINATION,
+                       Faults.NOT_RUNNING)
+
 def getFaultDescription(code):
     for faultname in Faults.__dict__:
         if getattr(Faults, faultname) == code:


### PR DESCRIPTION
New pull request because previous pull request was on my master.

Summary:
- error_status being set in supervisorctl.py raises a SystemExit when in non-interactive mode.
- handle_error wraps all error output and sets error_status.
- onecmd is the entry point for single command and where we enforce SystemExit returning with the error code set in handle_error.
- Updated the docs to reflect that we have non-zero exit codes for failure cases or app status not running.
- Fully tested.

@mnaberez - would love to get this one merged and done. Please let me know if there's anything I can do to get this to a point where you would feel comfortable with it, or if someone else needs to review it. It's the oldest bug in the project now.

Previous pull request ref: #641
Fixes #24