### PR TITLE
Fix for Missing trailing slash on inet_http_server redirects - #640

### DIFF
--- a/supervisor/web.py
+++ b/supervisor/web.py
@@ -427,7 +427,7 @@ class StatusView(MeldView):
                     return NOT_DONE_YET
                 if message is not None:
                     server_url = form['SERVER_URL']
-                    location = server_url + '?message=%s' % urllib.quote(
+                    location = server_url + "/" + '?message=%s' % urllib.quote(
                         message)
                     response['headers']['Location'] = location
 


### PR DESCRIPTION
get_server_url() strips the trailing "/", so it has to be added back on the redirect between the host and http args.

http.py
```python
    def get_server_url(self):
        """ Functionality that medusa's http request doesn't have; set an
        attribute named 'server_url' on the request based on the Host: header
        """
        default_port={'http': '80', 'https': '443'}
        environ = self.cgi_environment()
        if (environ.get('HTTPS') in ('on', 'ON') or
            environ.get('SERVER_PORT_SECURE') == "1"):
            # XXX this will currently never be true
            protocol = 'https'
        else:
            protocol = 'http'

        if 'HTTP_HOST' in environ:
            host = environ['HTTP_HOST'].strip()
            hostname, port = urllib.splitport(host)
        else:
            hostname = environ['SERVER_NAME'].strip()
            port = environ['SERVER_PORT']

        if port is None or default_port[protocol] == port:
            host = hostname
        else:
            host = hostname + ':' + port
        server_url = '%s://%s' % (protocol, host)
        if server_url[-1:]=='/':
            server_url=server_url[:-1]
        return server_url
```