### PR TITLE
Add a `settings` command to supervisorctl

### DIFF
--- a/supervisor/supervisorctl.py
+++ b/supervisor/supervisorctl.py
@@ -25,6 +25,7 @@ actions.
 import cmd
 import sys
 import getpass
+import json
 
 import socket
 import errno
@@ -1004,6 +1005,21 @@ class DefaultControllerPlugin(ControllerPluginBase):
         else:
             for pinfo in configinfo:
                 self.ctl.output(self._formatConfigInfo(pinfo))
+
+    def do_settings(self, arg):
+        supervisor = self.ctl.get_supervisor()
+        try:
+            configinfo = supervisor.getAllConfigInfo()
+        except xmlrpclib.Fault as e:
+            if e.faultCode == xmlrpc.Faults.SHUTDOWN_STATE:
+                self.ctl.output('ERROR: supervisor shutting down')
+            else:
+                raise
+        else:
+            for pinfo in configinfo:
+                if not arg or arg == pinfo['group']:
+                    self.ctl.output(
+                        json.dumps(pinfo, indent=4, sort_keys=True))
 
     def help_avail(self):
         self.ctl.output("avail\t\t\tDisplay all configured processes")


### PR DESCRIPTION
(Relies on https://github.com/Supervisor/supervisor/pull/670)

Example usage:

```
 $ supervisorctl settings sleep_and_die
 {
     "autostart": false,
     "command": "/bin/bash -c 'echo \"Sleeping a bit...\"; sleep 5; echo \"Exiting with exit code 1\"; exit 1'",
     "exitcodes": [
         0,
         2
     ],
     "group": "sleep_and_die",
     "group_prio": 999,
     "inuse": true,
     "killasgroup": false,
     "name": "sleep_and_die",
     "process_prio": 999,
     "redirect_stderr": false,
     "startretries": 0,
     "startsecs": 10,
     "stderr_capture_maxbytes": 0,
     "stderr_events_enabled": false,
     "stderr_logfile": "/Users/marca/dev/git-repos/supervisor/var/log/supervisor/sleep_and_die-stderr---supervisor-ekeD2B.log",
     "stderr_logfile_backups": 10,
     "stderr_logfile_maxbytes": 52428800,
     "stderr_syslog": false,
     "stdout_capture_maxbytes": 0,
     "stdout_events_enabled": false,
     "stdout_logfile": "/Users/marca/dev/git-repos/supervisor/var/log/supervisor/sleep_and_die-stdout---supervisor-Xh5DKb.log",
     "stdout_logfile_backups": 10,
     "stdout_logfile_maxbytes": 52428800,
     "stdout_syslog": false,
     "stopsignal": 15,
     "stopwaitsecs": 10
 }
```
