### PR TITLE
Write activity log to syslog when logfile=syslog

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -495,7 +495,8 @@ class ServerOptions(Options):
         else:
             logfile = section.logfile
 
-        self.logfile = normalize_path(logfile)
+        if not logfile == 'syslog':
+            self.logfile = normalize_path(logfile)
 
         if self.pidfile:
             pidfile = self.pidfile
@@ -2169,4 +2170,3 @@ class NoPermission(ProcessException):
     """ Indicates that the file cannot be executed because the supervisor
     process does not possess the appropriate UNIX filesystem permission
     to execute the file. """
-


### PR DESCRIPTION
When main configuration logfile=syslog, ServerOptions will not call (normalize_path)
to convert that option value to a real path (i.e., working_dir/syslog). Instead,
it passes that option to future loggers and that will make actitivy logs come to
(local) syslog receiver.