### PR TITLE
Add authentication prompts for non-interactive mode

### DIFF
--- a/supervisor/supervisorctl.py
+++ b/supervisor/supervisorctl.py
@@ -183,16 +183,13 @@ class Controller(cmd.Cmd):
                     return do_func(arg)
                 except xmlrpclib.ProtocolError as e:
                     if e.errcode == 401:
-                        if self.options.interactive:
-                            self.output('Server requires authentication')
-                            username = raw_input('Username:')
-                            password = getpass.getpass(prompt='Password:')
-                            self.output('')
-                            self.options.username = username
-                            self.options.password = password
-                            return self.onecmd(origline)
-                        else:
-                            self.options.usage('Server requires authentication')
+                        self.output('Server requires authentication')
+                        username = raw_input('Username:')
+                        password = getpass.getpass(prompt='Password:')
+                        self.output('')
+                        self.options.username = username
+                        self.options.password = password
+                        return self.onecmd(origline)
                     else:
                         raise
                 do_func(arg)


### PR DESCRIPTION
Supervisor only support authentication prompts for interactive mode, like:

```
$ supervisorctl -c /etc/supervisor/supervisord.conf
Server requires authentication
Username:
Password:
```

For those who want to use command args:

```
$ supervisorctl -c /etc/supervisor/supervisord.conf status
Error: Server requires authentication
For help, use /usr/local/bin/supervisorctl -h
```

Here comment out the `if` condition to add prompts instead of just printing out the usage for non-interactive mode.