### PR TITLE
Test that doc building + readme are correct

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    cover,cover3,py26,py27,py32,py33,py34,py35,pypy
+    cover,cover3,py26,py27,py32,py33,py34,py35,pypy,docs
 
 [testenv]
 deps =
@@ -24,3 +24,11 @@ commands =
     py.test --cov=supervisor --cov-report=term-missing --cov-report=xml {posargs}
 deps =
     {[testenv:cover]deps}
+
+[testenv:docs]
+deps =
+    sphinx
+    readme
+commands =
+    sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
+    python setup.py check -m -r -s


### PR DESCRIPTION
Currently you can see at [supervisor's pypi page](https://pypi.python.org/pypi/supervisor) that the long_description has failed to render.

This additional test env will test that
A) the docs build correctly
B) The readme can be rendered correctly

Very useful for making sure your readme changes don't bork anything (like pypi rendering).

the [readme](https://pypi.python.org/pypi/readme) package integrates into the `setup.py check -r -m -s` call.