### PR TITLE
expand the host node name option on includes

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -570,7 +570,9 @@ class ServerOptions(Options):
             if need_close:
                 fp.close()
 
-        expansions = {'here':self.here}
+        host_node_name = platform.node()
+        expansions = {'here':self.here,
+                      'host_node_name':host_node_name}
         expansions.update(self.environ_expansions)
         if parser.has_section('include'):
             parser.expand_here(self.here)


### PR DESCRIPTION
This adds support for this syntax in an include:

```
[include]
files = /etc/supervisor/supervisor.d/%(host_node_name)s/*.conf
```

This allows me to deploy the same directories to all of my hosts and let supervisor figure out which ones to load by what host it is running on.