### PR TITLE
Add mode to honor linebreaks in stdout

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -763,6 +763,7 @@ class ServerOptions(Options):
                 continue
             program_name = process_or_group_name(section.split(':', 1)[1])
             priority = integer(get(section, 'priority', 999))
+
             fcgi_expansions = {'program_name': program_name}
 
             # find proc_uid from "user" option
@@ -888,6 +889,7 @@ class ServerOptions(Options):
         stdout_events = boolean(get(section, 'stdout_events_enabled','false'))
         stderr_cmaxbytes = byte_size(get(section,'stderr_capture_maxbytes','0'))
         stderr_events = boolean(get(section, 'stderr_events_enabled','false'))
+        honor_log_linebreaks = boolean(get(section, 'honor_log_linebreaks', 'false'))
         serverurl = get(section, 'serverurl', None)
         if serverurl and serverurl.strip().upper() == 'AUTO':
             serverurl = None
@@ -992,6 +994,7 @@ class ServerOptions(Options):
                 stderr_logfile=logfiles['stderr_logfile'],
                 stderr_capture_maxbytes = stderr_cmaxbytes,
                 stderr_events_enabled = stderr_events,
+                honor_log_linebreaks=honor_log_linebreaks,
                 stderr_logfile_backups=logfiles['stderr_logfile_backups'],
                 stderr_logfile_maxbytes=logfiles['stderr_logfile_maxbytes'],
                 stderr_syslog=logfiles['stderr_syslog'],
@@ -1809,7 +1812,7 @@ class ProcessConfig(Config):
         'stderr_logfile_backups', 'stderr_logfile_maxbytes',
         'stderr_events_enabled', 'stderr_syslog',
         'stopsignal', 'stopwaitsecs', 'stopasgroup', 'killasgroup',
-        'exitcodes', 'redirect_stderr' ]
+        'exitcodes', 'redirect_stderr', 'honor_log_linebreaks' ]
     optional_param_names = [ 'environment', 'serverurl' ]
 
     def __init__(self, options, **params):

--- a/supervisor/skel/sample.conf
+++ b/supervisor/skel/sample.conf
@@ -89,6 +89,12 @@ serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
 ;environment=A="1",B="2"       ; process environment additions (def no adds)
 ;serverurl=AUTO                ; override serverurl computation (childutils)
 
+;[program:foohonorloglinebreaks]
+;stdout_logfile_maxbytes=1MB
+;stdout_logfile_backups=6
+;honor_log_linebreaks=true
+;command=foo
+
 ; The below sample eventlistener section shows all possible
 ; eventlistener subsection values, create one or more 'real'
 ; eventlistener: sections to be able to handle event notifications

--- a/supervisor/tests/base.py
+++ b/supervisor/tests/base.py
@@ -514,6 +514,7 @@ class DummyPConfig:
                  stdout_syslog=False,
                  stderr_logfile=None, stderr_capture_maxbytes=0,
                  stderr_events_enabled=False,
+                 honor_log_linebreaks=False,
                  stderr_logfile_backups=0, stderr_logfile_maxbytes=0,
                  stderr_syslog=False,
                  redirect_stderr=False,
@@ -531,6 +532,7 @@ class DummyPConfig:
         self.stdout_logfile = stdout_logfile
         self.stdout_capture_maxbytes = stdout_capture_maxbytes
         self.stdout_events_enabled = stdout_events_enabled
+        self.honor_log_linebreaks = honor_log_linebreaks
         self.stdout_logfile_backups = stdout_logfile_backups
         self.stdout_logfile_maxbytes = stdout_logfile_maxbytes
         self.stdout_syslog = stdout_syslog

--- a/supervisor/tests/test_dispatchers.py
+++ b/supervisor/tests/test_dispatchers.py
@@ -182,6 +182,28 @@ class POutputDispatcherTests(unittest.TestCase):
              "'process1' stdout output:\na")
         self.assertEqual(dispatcher.output_buffer, '')
 
+    def test_record_output_log_linebreakmode(self):
+        # stdout/stderr goes to the process log and the main log,
+        # in non-capturemode, the data length doesn't matter
+        options = DummyOptions()
+        from supervisor import loggers
+        options.loglevel = loggers.LevelsByName.TRAC
+        config = DummyPConfig(options, 'process1', '/bin/process1',
+                              stdout_logfile='/tmp/foo', honor_log_linebreaks=True)
+        process = DummyProcess(config)
+        dispatcher = self._makeOne(process)
+        dispatcher.output_buffer = 'a\nb'
+        dispatcher.record_output()
+        self.assertEqual(dispatcher.childlog.data, ['a\n'])
+        self.assertEqual(options.logger.data[0],
+             "'process1' stdout output:\na\n")
+        self.assertEqual(dispatcher.output_buffer, 'b')
+        dispatcher.record_output()
+        self.assertEqual(dispatcher.childlog.data, ['a\n', 'b'])
+        self.assertEqual(dispatcher.output_buffer, '')
+        self.assertEqual(options.logger.data[1],
+             "'process1' stdout output:\nb")
+
     def test_record_output_emits_stdout_event_when_enabled(self):
         options = DummyOptions()
         config = DummyPConfig(options, 'process1', '/bin/process1',

--- a/supervisor/tests/test_options.py
+++ b/supervisor/tests/test_options.py
@@ -3005,10 +3005,10 @@ class TestProcessConfig(unittest.TestCase):
                      'stdout_logfile', 'stdout_capture_maxbytes',
                      'stdout_events_enabled', 'stdout_syslog',
                      'stderr_logfile', 'stderr_capture_maxbytes',
-                     'stderr_events_enabled', 'stderr_syslog',
-                     'stopsignal', 'stopwaitsecs', 'stopasgroup',
-                     'killasgroup', 'exitcodes', 'redirect_stderr',
-                     'environment'):
+                     'stderr_events_enabled', 'honor_log_linebreaks',
+                     'stderr_syslog', 'stopsignal', 'stopwaitsecs',
+                     'stopasgroup', 'killasgroup', 'exitcodes',
+                     'redirect_stderr', 'environment'):
             defaults[name] = name
         for name in ('stdout_logfile_backups', 'stdout_logfile_maxbytes',
                      'stderr_logfile_backups', 'stderr_logfile_maxbytes'):
@@ -3085,12 +3085,12 @@ class EventListenerConfigTests(unittest.TestCase):
                      'priority', 'autostart', 'autorestart',
                      'startsecs', 'startretries', 'uid',
                      'stdout_logfile', 'stdout_capture_maxbytes',
-                     'stdout_events_enabled', 'stdout_syslog',
-                     'stderr_logfile', 'stderr_capture_maxbytes',
-                     'stderr_events_enabled', 'stderr_syslog',
-                     'stopsignal', 'stopwaitsecs', 'stopasgroup',
-                     'killasgroup', 'exitcodes', 'redirect_stderr',
-                     'environment'):
+                     'stdout_events_enabled', 'honor_log_linebreaks',
+                     'stdout_syslog', 'stderr_logfile',
+                     'stderr_capture_maxbytes', 'stderr_events_enabled',
+                     'stderr_syslog', 'stopsignal', 'stopwaitsecs',
+                     'stopasgroup', 'killasgroup', 'exitcodes',
+                     'redirect_stderr', 'environment'):
             defaults[name] = name
         for name in ('stdout_logfile_backups', 'stdout_logfile_maxbytes',
                      'stderr_logfile_backups', 'stderr_logfile_maxbytes'):
@@ -3133,12 +3133,12 @@ class FastCGIProcessConfigTest(unittest.TestCase):
                      'priority', 'autostart', 'autorestart',
                      'startsecs', 'startretries', 'uid',
                      'stdout_logfile', 'stdout_capture_maxbytes',
-                     'stdout_events_enabled', 'stdout_syslog',
-                     'stderr_logfile', 'stderr_capture_maxbytes',
-                     'stderr_events_enabled', 'stderr_syslog',
-                     'stopsignal', 'stopwaitsecs', 'stopasgroup',
-                     'killasgroup', 'exitcodes', 'redirect_stderr',
-                     'environment'):
+                     'stdout_events_enabled', 'honor_log_linebreaks',
+                     'stdout_syslog', 'stderr_logfile',
+                     'stderr_capture_maxbytes', 'stderr_events_enabled',
+                     'stderr_syslog', 'stopsignal', 'stopwaitsecs',
+                     'stopasgroup', 'killasgroup', 'exitcodes',
+                     'redirect_stderr', 'environment'):
             defaults[name] = name
         for name in ('stdout_logfile_backups', 'stdout_logfile_maxbytes',
                      'stderr_logfile_backups', 'stderr_logfile_maxbytes'):

--- a/supervisor/tests/test_supervisord.py
+++ b/supervisor/tests/test_supervisord.py
@@ -325,6 +325,7 @@ class SupervisordTests(unittest.TestCase):
                 'stdout_syslog': False,
                 'stderr_logfile': None, 'stderr_capture_maxbytes': 0,
                 'stderr_events_enabled': False,
+                'honor_log_linebreaks': False,
                 'stderr_logfile_backups': 0, 'stderr_logfile_maxbytes': 0,
                 'stderr_syslog': False,
                 'redirect_stderr': False,


### PR DESCRIPTION
In order to avoid line breaks in the middle of log lines (which
currently happens when the buffer is flushed) we need a variable length
buffer. This is solved by flushing only up to the next line break and
keeping the remainder of the current buffer until the next flush.

In this commit a config parameter for this is added:
honor_log_linebreaks=true

The default value is false to not break existing behaviour.
