### PR TITLE
Add a program option to update oom_score_adj for child processes.

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -891,6 +891,7 @@ class ServerOptions(Options):
         serverurl = get(section, 'serverurl', None)
         if serverurl and serverurl.strip().upper() == 'AUTO':
             serverurl = None
+        oom_score_adj = get(section, 'oom_score_adj', None)
 
         # find uid from "user" option
         user = get(section, 'user', None)
@@ -902,7 +903,6 @@ class ServerOptions(Options):
         umask = get(section, 'umask', None)
         if umask is not None:
             umask = octal_type(umask)
-
         process_name = process_or_group_name(
             get(section, 'process_name', '%(program_name)s', do_expand=False))
 
@@ -1001,6 +1001,7 @@ class ServerOptions(Options):
                 killasgroup=killasgroup,
                 exitcodes=exitcodes,
                 redirect_stderr=redirect_stderr,
+                oom_score_adj=oom_score_adj,
                 environment=environment,
                 serverurl=serverurl)
 
@@ -1571,6 +1572,14 @@ class ServerOptions(Options):
             if fd is not None:
                 self.close_fd(fd)
 
+    def set_oom_score_adj(self, oom_score_adj):
+        try:
+            procfile = open('/proc/%s/oom_score_adj' % os.getpid(), 'w')
+            procfile.write(str(oom_score_adj) + '\n')
+            procfile.close()
+        except IOError:
+            return "Can't set oom_score_adj to %s" % oom_score_adj
+
 class ClientOptions(Options):
     positional_args_allowed = 1
 
@@ -1809,7 +1818,7 @@ class ProcessConfig(Config):
         'stderr_logfile_backups', 'stderr_logfile_maxbytes',
         'stderr_events_enabled', 'stderr_syslog',
         'stopsignal', 'stopwaitsecs', 'stopasgroup', 'killasgroup',
-        'exitcodes', 'redirect_stderr' ]
+        'exitcodes', 'redirect_stderr', 'oom_score_adj' ]
     optional_param_names = [ 'environment', 'serverurl' ]
 
     def __init__(self, options, **params):

--- a/supervisor/process.py
+++ b/supervisor/process.py
@@ -296,6 +296,13 @@ class Subprocess(object):
             self._prepare_child_fds()
             # sending to fd 2 will put this output in the stderr log
 
+            # set oom_score_adj, better to do it before dropping privileges
+            # so it can also be decreased
+            oom_score_adj_msg = self.set_oom_score_adj()
+            if oom_score_adj_msg:
+                options.write(2, "supervisor: %s\n" % oom_score_adj_msg)
+                return
+
             # set user
             setuid_msg = self.set_uid()
             if setuid_msg:
@@ -572,6 +579,11 @@ class Subprocess(object):
             return
         msg = self.config.options.dropPrivileges(self.config.uid)
         return msg
+
+    def set_oom_score_adj(self):
+        if self.config.oom_score_adj is None:
+            return
+        return self.config.options.set_oom_score_adj(self.config.oom_score_adj)
 
     def __lt__(self, other):
         return self.config.priority < other.config.priority

--- a/supervisor/tests/base.py
+++ b/supervisor/tests/base.py
@@ -87,6 +87,7 @@ class DummyOptions:
         self.changed_directory = False
         self.chdir_error = None
         self.umaskset = None
+        self.oom_score_adj_set = None
         self.poller = DummyPoller(self)
 
     def getLogger(self, *args, **kw):
@@ -260,6 +261,9 @@ class DummyOptions:
 
     def setumask(self, mask):
         self.umaskset = mask
+
+    def set_oom_score_adj(self, oom_score_adj):
+        self.oom_score_adj_set = oom_score_adj
 
 class DummyLogger:
     level = None
@@ -518,7 +522,8 @@ class DummyPConfig:
                  stderr_syslog=False,
                  redirect_stderr=False,
                  stopsignal=None, stopwaitsecs=10, stopasgroup=False, killasgroup=False,
-                 exitcodes=(0,2), environment=None, serverurl=None):
+                 exitcodes=(0,2), environment=None, serverurl=None,
+                 oom_score_adj=None):
         self.options = options
         self.name = name
         self.command = command
@@ -554,6 +559,7 @@ class DummyPConfig:
         self.umask = umask
         self.autochildlogs_created = False
         self.serverurl = serverurl
+        self.oom_score_adj = oom_score_adj
 
     def create_autochildlogs(self):
         self.autochildlogs_created = True

--- a/supervisor/tests/test_options.py
+++ b/supervisor/tests/test_options.py
@@ -3008,7 +3008,7 @@ class TestProcessConfig(unittest.TestCase):
                      'stderr_events_enabled', 'stderr_syslog',
                      'stopsignal', 'stopwaitsecs', 'stopasgroup',
                      'killasgroup', 'exitcodes', 'redirect_stderr',
-                     'environment'):
+                     'environment', 'oom_score_adj'):
             defaults[name] = name
         for name in ('stdout_logfile_backups', 'stdout_logfile_maxbytes',
                      'stderr_logfile_backups', 'stderr_logfile_maxbytes'):
@@ -3090,7 +3090,7 @@ class EventListenerConfigTests(unittest.TestCase):
                      'stderr_events_enabled', 'stderr_syslog',
                      'stopsignal', 'stopwaitsecs', 'stopasgroup',
                      'killasgroup', 'exitcodes', 'redirect_stderr',
-                     'environment'):
+                     'environment', 'oom_score_adj'):
             defaults[name] = name
         for name in ('stdout_logfile_backups', 'stdout_logfile_maxbytes',
                      'stderr_logfile_backups', 'stderr_logfile_maxbytes'):
@@ -3138,7 +3138,7 @@ class FastCGIProcessConfigTest(unittest.TestCase):
                      'stderr_events_enabled', 'stderr_syslog',
                      'stopsignal', 'stopwaitsecs', 'stopasgroup',
                      'killasgroup', 'exitcodes', 'redirect_stderr',
-                     'environment'):
+                     'environment', 'oom_score_adj'):
             defaults[name] = name
         for name in ('stdout_logfile_backups', 'stdout_logfile_maxbytes',
                      'stderr_logfile_backups', 'stderr_logfile_maxbytes'):

--- a/supervisor/tests/test_process.py
+++ b/supervisor/tests/test_process.py
@@ -420,6 +420,24 @@ class SubprocessTests(unittest.TestCase):
         self.assertEqual(options.written,
              {2: "supervisor: child process was not spawned\n"})
 
+    def test_spawn_as_child_sets_oom_score_adj(self):
+        options = DummyOptions()
+        options.forkpid = 0
+        config = DummyPConfig(options, 'good', '/good/filename',
+                              oom_score_adj=100)
+        instance = self._makeOne(config)
+        result = instance.spawn()
+        self.assertEqual(result, None)
+        self.assertEqual(options.execv_args,
+                         ('/good/filename', ['/good/filename']) )
+        self.assertEqual(options.oom_score_adj_set, 100)
+        self.assertEqual(options.execve_called, True)
+        # if the real execve() succeeds, the code that writes the
+        # "was not spawned" message won't be reached.  this assertion
+        # is to test that no other errors were written.
+        self.assertEqual(options.written,
+             {2: "supervisor: child process was not spawned\n"})
+
     def test_spawn_as_child_cwd_fail(self):
         options = DummyOptions()
         options.forkpid = 0

--- a/supervisor/tests/test_supervisord.py
+++ b/supervisor/tests/test_supervisord.py
@@ -332,6 +332,7 @@ class SupervisordTests(unittest.TestCase):
                 'stopasgroup': False,
                 'killasgroup': False,
                 'exitcodes': (0,2), 'environment': None, 'serverurl': None,
+                'oom_score_adj': None
             }
             result.update(params)
             return ProcessConfig(options, **result)


### PR DESCRIPTION
Configuring the oom_score_adj value for child processes is a useful way of controlling the kernel's out-of-memory killer behavior.  Other modern process managers (e.g. systemd, Upstart) also support it and it makes a lot of sense for Supervisor to do as well.
