### PR TITLE
Fixed race condition per https://github.com/scottp-dpaw/supervisor/pu…

### DIFF
--- a/supervisor/process.py
+++ b/supervisor/process.py
@@ -477,7 +477,7 @@ class Subprocess(object):
             msg = 'unknown problem sending sig %s (%s):%s' % (
                                 self.config.name, self.pid, tb)
             options.logger.critical(msg)
-            self.change_state(ProcessStates.UNKNOWN)
+            self.change_state(ProcessStates.FATAL)
             self.pid = 0
             return msg
 
@@ -525,7 +525,7 @@ class Subprocess(object):
             self._assertInState(ProcessStates.STARTING)
             self.change_state(ProcessStates.BACKOFF)
 
-        else:
+        elif self.pid != 0:
             # this finish was not the result of a stop request, the
             # program was in the RUNNING state but exited
             # implies RUNNING -> EXITED normally but see next comment


### PR DESCRIPTION
…ll/1/files

Fixed race condition per: https://github.com/scottp-dpaw/supervisor/pull/1/files

We've seen supervisor crash multiple times due to the 'UNKNOWN' process state, the processes continue running but they become detached from supervisor and need to be killed manually prior to supervisor restart. 

We've had this patch running live for a few weeks and we haven't seen any issues on our patched systems but continue to see the problem on our unpatched systems. 