### PR TITLE
Exit if args given to reload

### DIFF
--- a/supervisor/supervisorctl.py
+++ b/supervisor/supervisorctl.py
@@ -983,6 +983,11 @@ class DefaultControllerPlugin(ControllerPluginBase):
         self.ctl.output("shutdown \tShut the remote supervisord down.")
 
     def do_reload(self, arg):
+        if arg:
+            self.ctl.output('Error: reload given with a process name. Maybe you meant restart?')
+            self.help_reload()
+            return
+ 
         if self.ctl.options.interactive:
             yesno = raw_input('Really restart the remote supervisord process '
                               'y/N? ')


### PR DESCRIPTION
Users can accidentally confuse reload (reload the entire supervisor and all children) with restart (restart a single child).  This keeps reload from working if a trailing argument is given.