### PR TITLE
Fix #787

### DIFF
--- a/supervisor/process.py
+++ b/supervisor/process.py
@@ -123,6 +123,8 @@ class Subprocess(object):
                 st = None
 
         else:
+            if self.config.environment is not None:
+                os.environ.update(self.config.environment)
             path = self.config.options.get_path()
             found = None
             st = None
@@ -923,6 +925,3 @@ def new_serial(inst):
         inst.serial = -1
     inst.serial += 1
     return inst.serial
-
-
-


### PR DESCRIPTION
ref: https://github.com/Supervisor/supervisor/issues/787#issuecomment-233224771

@mnaberez. I know why can't find command 'gunicorn'

This error raise at https://github.com/Supervisor/supervisor/blob/master/supervisor/process.py#L216

because before execute [get_path method](https://github.com/Supervisor/supervisor/blob/master/supervisor/process.py#L126),  env is not updated, so `get_path()`"s result not contains `%(ENV_HOME)s/.virtualenvs/venv/bin`

You can create a simple example with virtualenv env to find out this.