### PR TITLE
Fixed logfile output to special files like /dev/stdout on Python 3.

### DIFF
--- a/supervisor/tests/test_loggers.py
+++ b/supervisor/tests/test_loggers.py
@@ -231,7 +231,7 @@ class StdoutTests(StdoutTestsBase):
         handler = self._makeOne('/dev/stdout')
         # Modes 'w' and 'a' have the same semantics when applied to
         # character device files and fifos.
-        self.assertIn(handler.mode, ['w', 'a'])
+        self.assertTrue(handler.mode in ['w', 'a'], handler.mode)
         self.assertEqual(handler.baseFilename, '/dev/stdout')
         self.assertEqual(handler.stream.name, '/dev/stdout')
         handler.close()

--- a/supervisor/tests/test_loggers.py
+++ b/supervisor/tests/test_loggers.py
@@ -220,6 +220,22 @@ class FileHandlerTests(HandlerTests, unittest.TestCase):
         self.assertTrue(dummy_stderr.written.endswith('OSError\n'),
                         dummy_stderr.written)
 
+if os.path.exists('/dev/stdout'):
+    StdoutTestsBase = FileHandlerTests
+else:
+    # Skip the stdout tests on platforms that don't have /dev/stdout.
+    StdoutTestsBase = object
+
+class StdoutTests(StdoutTestsBase):
+    def test_ctor_with_dev_stdout(self):
+        handler = self._makeOne('/dev/stdout')
+        # Modes 'w' and 'a' have the same semantics when applied to
+        # character device files and fifos.
+        self.assertIn(handler.mode, ['w', 'a'])
+        self.assertEqual(handler.baseFilename, '/dev/stdout')
+        self.assertEqual(handler.stream.name, '/dev/stdout')
+        handler.close()
+
 class RotatingFileHandlerTests(FileHandlerTests):
 
     def _getTargetClass(self):


### PR DESCRIPTION
Python 3.5.2 disallows `open('/dev/stdout', 'a')` (it causes OSError with errno=ESPIPE) but allows `open('/dev/stdout', 'w')`. This change makes Supervisor detect this error condition and fix it if possible.

(I might try to get this fixed in Python itself, but this patch helps Supervisor work with existing Python 3 installations.)