### PR TITLE
Correct redirect_stderr target in 3.0a1 release note

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1283,7 +1283,7 @@
   "stdout_logfile_backups", and "stdout_logfile_maxbytes".  Added
   keys include "stderr_logfile", "stderr_logfile_backups", and
   "stderr_logfile_maxbytes".  An additional "redirect_stderr" key is
-  used to cause program stderr output to be sent to its stdin
+  used to cause program stderr output to be sent to its stdout
   channel.  The keys "log_stderr" and "log_stdout" have been
   removed.
 


### PR DESCRIPTION
Changing history is frowned upon, but this change doesn't match what the code actually does (nor does it match the documentation). Since it could be confusing, I think it's definitely worth fixing.