### PR TITLE
Fix reverse proxy message redirect after web action

### DIFF
--- a/supervisor/web.py
+++ b/supervisor/web.py
@@ -462,8 +462,7 @@ class StatusView(MeldView):
                 if message is NOT_DONE_YET:
                     return NOT_DONE_YET
                 if message is not None:
-                    server_url = form['SERVER_URL']
-                    location = server_url + '?message=%s' % urllib.quote(
+                    location = 'index.html?message=%s' % urllib.quote(
                         message)
                     response['headers']['Location'] = location
 


### PR DESCRIPTION
This small change allows supervisor HTTP server to be served behind a reverse proxy like nginx by fixing the redirect (the only one in web.py).

This is temporary until version 4.0 is launched with the configurable `base_path` (#593), given the release cycles are so big & there are so much left to do for the python 3 release.

This works very well behind nginx HTTPS offloading without any hack in the configuration:
```
        location /supervisor/job/ {
                proxy_pass http://10.107.0.10:9001/;
                include includes/proxy-parameters;
        }
```

I know you already refused this once in PR #495, but I would kindly ask you to reconsider this, it's not breaking anything, there are already only relative links in the whole web interface, so I can't see why this one should not be. This way you actually don't need any `base_path` anymore.

Related to #29, #827, makes #669 redundant.