### PR TITLE
Support forwarding stdout of processes to supervisor stdout

### DIFF
--- a/supervisor/loggers.py
+++ b/supervisor/loggers.py
@@ -395,7 +395,10 @@ def handle_syslog(logger, fmt):
 def handle_file(logger, filename, fmt, rotating=False, maxbytes=0, backups=0):
     if filename == 'syslog':
         handler = SyslogHandler()
-
+    elif filename == 'stdout':
+        handler = StreamHandler(sys.stdout)
+    elif filename == 'stderr':
+        handler = StreamHandler(sys.stderr)
     else:
         if rotating is False:
             handler = FileHandler(filename)


### PR DESCRIPTION
This supports a common container use-case where supervisor is pid 1 in a
container and the container manager will be collecting and recording the
output of supervisor.  Users can now specify:

    stdout_logfile=stdout
    stderr_logfile=stderr

and supervisor will pass any messages logged strieght through.