### PR TITLE
Fix buffer type in dispatcher

### DIFF
--- a/supervisor/dispatchers.py
+++ b/supervisor/dispatchers.py
@@ -465,7 +465,7 @@ class PInputDispatcher(PDispatcher):
 
     def __init__(self, process, channel, fd):
         PDispatcher.__init__(self, process, channel, fd)
-        self.input_buffer = ''
+        self.input_buffer = b''
 
     def writable(self):
         if self.input_buffer and not self.closed:
@@ -487,7 +487,7 @@ class PInputDispatcher(PDispatcher):
                 self.flush()
             except OSError as why:
                 if why.args[0] == errno.EPIPE:
-                    self.input_buffer = ''
+                    self.input_buffer = b''
                     self.close()
                 else:
                     raise

--- a/supervisor/tests/test_dispatchers.py
+++ b/supervisor/tests/test_dispatchers.py
@@ -568,9 +568,9 @@ class PInputDispatcherTests(unittest.TestCase):
         config = DummyPConfig(options, 'test', '/test')
         process = DummyProcess(config)
         dispatcher = self._makeOne(process)
-        self.assertEqual(dispatcher.input_buffer, '')
+        self.assertEqual(dispatcher.input_buffer, b'')
         dispatcher.handle_write_event()
-        self.assertEqual(dispatcher.input_buffer, '')
+        self.assertEqual(dispatcher.input_buffer, b'')
         self.assertEqual(options.written, {})
 
     def test_handle_write_event_epipe_raised(self):
@@ -582,7 +582,7 @@ class PInputDispatcherTests(unittest.TestCase):
         import errno
         options.write_error = errno.EPIPE
         dispatcher.handle_write_event()
-        self.assertEqual(dispatcher.input_buffer, '')
+        self.assertEqual(dispatcher.input_buffer, b'')
         self.assertTrue(options.logger.data[0].startswith(
             'fd 0 closed, stopped monitoring'))
         self.assertTrue(options.logger.data[0].endswith('(stdin)>'))


### PR DESCRIPTION
This fixes the error seen in #663, #835 and #836, but seems to expose further errors.