### PR TITLE
Explicitly document minfds limit inheritance

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -315,7 +315,8 @@ follows.
   is run as root.  supervisord uses file descriptors liberally, and will
   enter a failure mode when one cannot be obtained from the OS, so it's
   useful to be able to specify a minimum value to ensure it doesn't run out
-  of them during execution. This option is particularly useful on Solaris,
+  of them during execution.  These limits will be inherited by the managed
+  subprocesses.  This option is particularly useful on Solaris,
   which has a low per-process fd limit by default.
 
   *Default*:  1024


### PR DESCRIPTION
Child processes will inherit the file descriptor limits, so this amends the documentation to make this absolutely clear, as discussed in #813.