### PR TITLE
Fix 100% CPU usage

### DIFF
--- a/supervisor/poller.py
+++ b/supervisor/poller.py
@@ -131,7 +131,9 @@ class PollPoller(BasePoller):
             # When a process quits it's `fd`s are closed so there
             # is no more reason to keep this `fd` registered
             # If the process restarts it's `fd`s are registered again
-            self.unregister(fd)
+            self._poller.unregister(fd)
+            self.readables.discard(fd)
+            self.writables.discard(fd)
             return True
         return False
 

--- a/supervisor/supervisord.py
+++ b/supervisor/supervisord.py
@@ -221,9 +221,8 @@ class Supervisor:
                             'read event caused by %(dispatcher)r',
                             dispatcher=dispatcher)
                         dispatcher.handle_read_event()
-                        if (not dispatcher.readable()
-                                and not dispatcher.writable()):
-                            self.options.poller.unregister(fd)
+                        if not dispatcher.readable():
+                            self.options.poller.unregister_readable(fd)
                     except asyncore.ExitNow:
                         raise
                     except:
@@ -237,9 +236,8 @@ class Supervisor:
                             'write event caused by %(dispatcher)r',
                             dispatcher=dispatcher)
                         dispatcher.handle_write_event()
-                        if (not dispatcher.readable()
-                                and not dispatcher.writable()):
-                            self.options.poller.unregister(fd)
+                        if not dispatcher.writable():
+                            self.options.poller.unregister_writable(fd)
                     except asyncore.ExitNow:
                         raise
                     except:

--- a/supervisor/tests/test_poller.py
+++ b/supervisor/tests/test_poller.py
@@ -274,7 +274,6 @@ class KQueuePollerTests(KQueuePollerTestsBase):
         self.assertEqual(kevent.filter, filter)
         self.assertEqual(kevent.flags, flags)
 
-
 if implements_poll():
     PollerPollTestsBase = unittest.TestCase
 else:
@@ -367,8 +366,7 @@ class DummySelectPoll(object):
         self.error = error
         self.registered_as_readable = []
         self.registered_as_writable = []
-        self.unregistered_readables = []
-        self.unregistered_writables = []
+        self.unregistered = []
 
     def register(self, fd, eventmask):
         if eventmask == select.POLLIN | select.POLLPRI | select.POLLHUP:
@@ -378,11 +376,8 @@ class DummySelectPoll(object):
         else:
             raise ValueError("Registered a fd on unknown eventmask: '{0}'".format(eventmask))
 
-    def unregister_readable(self, fd):
-        self.unregistered_readables.append(fd)
-
-    def unregister_writable(self, fd):
-        self.unregistered_writables.append(fd)
+    def unregister(self, fd):
+        self.unregistered.append(fd)
 
     def poll(self, timeout):
         if self.error:

--- a/supervisor/tests/test_poller.py
+++ b/supervisor/tests/test_poller.py
@@ -26,9 +26,13 @@ class BasePollerTests(unittest.TestCase):
         inst = self._makeOne(None)
         self.assertRaises(NotImplementedError, inst.register_writable, None)
 
-    def test_unregister(self):
+    def test_unregister_readable(self):
         inst = self._makeOne(None)
-        self.assertRaises(NotImplementedError, inst.unregister, None)
+        self.assertRaises(NotImplementedError, inst.unregister_readable, None)
+
+    def test_unregister_writable(self):
+        inst = self._makeOne(None)
+        self.assertRaises(NotImplementedError, inst.unregister_writable, None)
 
     def test_poll(self):
         inst = self._makeOne(None)
@@ -59,16 +63,28 @@ class SelectPollerTests(unittest.TestCase):
         poller.register_writable(7)
         self.assertEqual(sorted(poller.writables), [6,7])
 
-    def test_unregister(self):
+    def test_unregister_readable(self):
         poller = self._makeOne(DummyOptions())
         poller.register_readable(6)
         poller.register_readable(7)
         poller.register_writable(8)
         poller.register_writable(9)
-        poller.unregister(6)
-        poller.unregister(9)
-        poller.unregister(100)  # not registered, ignore error
+        poller.unregister_readable(6)
+        poller.unregister_readable(9)
+        poller.unregister_readable(100)  # not registered, ignore error
         self.assertEqual(list(poller.readables), [7])
+        self.assertEqual(list(poller.writables), [8, 9])
+
+    def test_unregister_writable(self):
+        poller = self._makeOne(DummyOptions())
+        poller.register_readable(6)
+        poller.register_readable(7)
+        poller.register_writable(8)
+        poller.register_writable(6)
+        poller.unregister_writable(7)
+        poller.unregister_writable(6)
+        poller.unregister_writable(100)  # not registered, ignore error
+        self.assertEqual(list(poller.readables), [6, 7])
         self.assertEqual(list(poller.writables), [8])
 
     def test_poll_returns_readables_and_writables(self):
@@ -139,19 +155,37 @@ class KQueuePollerTests(KQueuePollerTestsBase):
         self.assertEqual(len(kqueue.registered_kevents), 1)
         self.assertWriteEventAdded(kqueue.registered_kevents[0], 7)
 
-    def test_unregister(self):
+    def test_unregister_readable(self):
         kqueue = DummyKQueue()
         poller = self._makeOne(DummyOptions())
         poller._kqueue = kqueue
         poller.register_writable(7)
         poller.register_readable(8)
-        poller.unregister(7)
-        poller.unregister(100)  # not registered, ignore error
+        poller.unregister_readable(7)
+        poller.unregister_readable(8)
+        poller.unregister_readable(100)  # not registered, ignore error
+        self.assertEqual(list(poller.writables), [7])
+        self.assertEqual(list(poller.readables), [])
+        self.assertWriteEventAdded(kqueue.registered_kevents[0], 7)
+        self.assertReadEventAdded(kqueue.registered_kevents[1], 8)
+        self.assertReadEventDeleted(kqueue.registered_kevents[2], 7)
+        self.assertReadEventDeleted(kqueue.registered_kevents[3], 8)
+
+    def test_unregister_writable(self):
+        kqueue = DummyKQueue()
+        poller = self._makeOne(DummyOptions())
+        poller._kqueue = kqueue
+        poller.register_writable(7)
+        poller.register_readable(8)
+        poller.unregister_writable(7)
+        poller.unregister_writable(8)
+        poller.unregister_writable(100)  # not registered, ignore error
         self.assertEqual(list(poller.writables), [])
         self.assertEqual(list(poller.readables), [8])
         self.assertWriteEventAdded(kqueue.registered_kevents[0], 7)
         self.assertReadEventAdded(kqueue.registered_kevents[1], 8)
-        self.assertDeletedEvent(kqueue.registered_kevents[2], 7)
+        self.assertWriteEventDeleted(kqueue.registered_kevents[2], 7)
+        self.assertWriteEventDeleted(kqueue.registered_kevents[3], 8)
 
     def test_poll_returns_readables_and_writables(self):
         kqueue = DummyKQueue(result=[(6, select.KQ_FILTER_READ),
@@ -229,9 +263,11 @@ class KQueuePollerTests(KQueuePollerTestsBase):
     def assertWriteEventAdded(self, kevent, fd):
         self.assertKevent(kevent, fd, select.KQ_FILTER_WRITE, select.KQ_EV_ADD)
 
-    def assertDeletedEvent(self, kevent, fd):
-        self.assertKevent(kevent, fd, select.KQ_FILTER_READ | select.KQ_FILTER_WRITE,
-                          select.KQ_EV_DELETE)
+    def assertReadEventDeleted(self, kevent, fd):
+        self.assertKevent(kevent, fd, select.KQ_FILTER_READ, select.KQ_EV_DELETE)
+
+    def assertWriteEventDeleted(self, kevent, fd):
+        self.assertKevent(kevent, fd, select.KQ_FILTER_WRITE, select.KQ_EV_DELETE)
 
     def assertKevent(self, kevent, ident, filter, flags):
         self.assertEqual(kevent.ident, ident)
@@ -331,7 +367,8 @@ class DummySelectPoll(object):
         self.error = error
         self.registered_as_readable = []
         self.registered_as_writable = []
-        self.unregistered = []
+        self.unregistered_readables = []
+        self.unregistered_writables = []
 
     def register(self, fd, eventmask):
         if eventmask == select.POLLIN | select.POLLPRI | select.POLLHUP:
@@ -341,8 +378,11 @@ class DummySelectPoll(object):
         else:
             raise ValueError("Registered a fd on unknown eventmask: '{0}'".format(eventmask))
 
-    def unregister(self, fd):
-        self.unregistered.append(fd)
+    def unregister_readable(self, fd):
+        self.unregistered_readables.append(fd)
+
+    def unregister_writable(self, fd):
+        self.unregistered_writables.append(fd)
 
     def poll(self, timeout):
         if self.error:


### PR DESCRIPTION
I ran into this bug using the web UI on macOS. It seems that https://github.com/Supervisor/supervisor/pull/589 was on the right track but has unnecessarily strict rules to unregister a file descriptor. Only need to check if the writers are not writeable anymore - readers not readable.