### PR TITLE
Update documentation regarding xml-rpc communication

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3,7 +3,19 @@
 XML-RPC API Documentation
 =========================
 
-To use the XML-RPC interface, connect to supervisor's HTTP port
+
+
+
+
+To use the XML-RPC interface, first make sure it has been configured 
+properly by specifying the rpcinterface_factory in your conf file:
+
+.. code-block:: ini
+    
+    [rpcinterface:supervisor]  
+    supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+Then you can connect to supervisor's HTTP port
 with any XML-RPC client library and run commands against it.  An
 example of doing this using Python's ``xmlrpclib`` client library
 is as follows.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3,17 +3,8 @@
 XML-RPC API Documentation
 =========================
 
-
-
-
-
-To use the XML-RPC interface, first make sure it has been configured 
-properly by specifying the rpcinterface_factory in your conf file:
-
-.. code-block:: ini
-    
-    [rpcinterface:supervisor]  
-    supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+To use the XML-RPC interface, first make sure you have configured the interface
+factory properly by setting the default factory. See :ref:`rpcinterface_factories`.
 
 Then you can connect to supervisor's HTTP port
 with any XML-RPC client library and run commands against it.  An
@@ -380,4 +371,3 @@ System Methods
     .. automethod:: methodSignature
 
     .. automethod:: multicall
-


### PR DESCRIPTION
There are a couple of pages of docs about using xml-rpc to communicate with supervisor, however on the main demo page `docs/api.rst`, there is nothing about specifying the `rpcinterface`.

So that people in the future don't have to go through the issue I had for a few days of just failing to be able to communicate with the supervisor, I placed the code-block of how to specify the `rpcinterface` directly into the `docs/api.rst` page.