### PR TITLE
Add a couple of common python dirs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ htmlcov/
 tmp/
 coverage.xml
 nosetests.xml
+.cache/

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ build/
 docs/.build/
 dist/
 env*/
+venv*/
 htmlcov/
 tmp/
 coverage.xml


### PR DESCRIPTION
This adds the `venv` (a common dir for virtual envs) and `.cache` (used by pip while building) directories to `.gitignore`.