### PR TITLE
Decode `chars` before appending to input buffer

### DIFF
--- a/supervisor/process.py
+++ b/supervisor/process.py
@@ -96,8 +96,9 @@ class Subprocess(object):
         dispatcher = self.dispatchers[stdin_fd]
         if dispatcher.closed:
             raise OSError(errno.EPIPE, "Process' stdin channel is closed")
-
-        dispatcher.input_buffer += chars
+        dispatcher.input_buffer += chars.decode() \
+            if isinstance(chars, bytes) \
+            else chars
         dispatcher.flush() # this must raise EPIPE if the pipe is closed
 
     def get_execv_args(self):


### PR DESCRIPTION
Resolves: #663 

This PR ensures that `decode` is used before appending `chars` to the `input_buffer` in `supervisor.process.SubProcess.write()` to ensure compatibility with Python 2 and 3.

This does not attempt to resolve the full port to handle Python 3 byte/string issues, but rather focuses on a simple fix that is reusable without change when all strings are converted to byte-strings.

Tested locally with py27 and py36.