### PR TITLE
Update http.py

### DIFF
--- a/supervisor/http.py
+++ b/supervisor/http.py
@@ -752,7 +752,7 @@ class logtail_handler:
 
         mtime = os.stat(logfile)[stat.ST_MTIME]
         request['Last-Modified'] = http_date.build_http_date(mtime)
-        request['Content-Type'] = 'text/plain'
+        request['Content-Type'] = 'text/plain;charset=utf-8'
         # the lack of a Content-Length header makes the outputter
         # send a 'Transfer-Encoding: chunked' response
 
@@ -783,7 +783,7 @@ class mainlogtail_handler:
 
         mtime = os.stat(logfile)[stat.ST_MTIME]
         request['Last-Modified'] = http_date.build_http_date(mtime)
-        request['Content-Type'] = 'text/plain'
+        request['Content-Type'] = 'text/plain;charset=utf-8'
         # the lack of a Content-Length header makes the outputter
         # send a 'Transfer-Encoding: chunked' response
 

--- a/supervisor/tests/test_http.py
+++ b/supervisor/tests/test_http.py
@@ -69,7 +69,7 @@ class LogtailHandlerTests(HandlerTests, unittest.TestCase):
             from supervisor.medusa import http_date
             self.assertEqual(request.headers['Last-Modified'],
                 http_date.build_http_date(os.stat(t)[stat.ST_MTIME]))
-            self.assertEqual(request.headers['Content-Type'], 'text/plain')
+            self.assertEqual(request.headers['Content-Type'], 'text/plain;charset=utf-8')
             self.assertEqual(len(request.producers), 1)
             self.assertEqual(request._done, True)
 
@@ -105,7 +105,7 @@ class MainLogTailHandlerTests(HandlerTests, unittest.TestCase):
             from supervisor.medusa import http_date
             self.assertEqual(request.headers['Last-Modified'],
                 http_date.build_http_date(os.stat(t)[stat.ST_MTIME]))
-            self.assertEqual(request.headers['Content-Type'], 'text/plain')
+            self.assertEqual(request.headers['Content-Type'], 'text/plain;charset=utf-8')
             self.assertEqual(len(request.producers), 1)
             self.assertEqual(request._done, True)
 


### PR DESCRIPTION
Fixes #811 (set UTF8 encoding in tail -f)