### PR TITLE
print "stayed up for > x seconds" instead of "stayed up for > than x seconds"

### DIFF
--- a/supervisor/process.py
+++ b/supervisor/process.py
@@ -627,7 +627,7 @@ class Subprocess(object):
                 self.change_state(ProcessStates.RUNNING)
                 msg = (
                     'entered RUNNING state, process has stayed up for '
-                    '> than %s seconds (startsecs)' % self.config.startsecs)
+                    '> %s seconds (startsecs)' % self.config.startsecs)
                 logger.info('success: %s %s' % (self.config.name, msg))
 
         if state == ProcessStates.BACKOFF:


### PR DESCRIPTION
Because `for longer than than x seconds` doesn't look nice and is not gramatically correct, well not literally. But the `>` sign is a `greater-than` (or `more-than` or - fitting for our use-case - `longer-than`) sign which translates to `for greater than than x seconds` or `for longer than than x seconds` instead of `for greater than x seconds` or `for longer than x seconds`.