### PR TITLE
two patches

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -917,7 +917,6 @@ class ServerOptions(Options):
             for one_dir in autodir:
                 if not os.path.exists(one_dir):
                     os.makedirs(one_dir)
-                    print 'autodir %s created' % one_dir
             #end of new directive: autodir
 
             for k in ('stdout', 'stderr'):

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -895,6 +895,10 @@ class ServerOptions(Options):
             raise ValueError(
                 "Cannot set stopasgroup=true and killasgroup=false"
                 )
+        #begin of new directive: autodir
+        #will create these dirs later before create the log file
+        autodir_str = get(section, 'autodir', '', do_expand=False)
+        #end of new directive: autodir
 
         for process_num in range(numprocs_start, numprocs + numprocs_start):
             expansions = common_expansions
@@ -907,6 +911,14 @@ class ServerOptions(Options):
             directory = get(section, 'directory', None)
 
             logfiles = {}
+
+            #begine of new directive: autodir
+            autodir = list_of_strings(expand(autodir_str, expansions, 'autodir'))
+            for one_dir in autodir:
+                if not os.path.exists(one_dir):
+                    os.makedirs(one_dir)
+                    print 'autodir %s created' % one_dir
+            #end of new directive: autodir
 
             for k in ('stdout', 'stderr'):
                 n = '%s_logfile' % k

--- a/supervisor/web.py
+++ b/supervisor/web.py
@@ -463,7 +463,7 @@ class StatusView(MeldView):
                     return NOT_DONE_YET
                 if message is not None:
                     server_url = form['SERVER_URL']
-                    location = server_url + '?message=%s' % urllib.quote(
+                    location = '?message=%s' % urllib.quote(
                         message)
                     response['headers']['Location'] = location
 


### PR DESCRIPTION
1. fixed the issue: the message url will redirect to root. this will be a problem when supervisor is deployed into a subdir instead of the root of the website.

2. add a new directive I really need: autodir
can use it in the conf file like this:
autodir=%(ENV_XXXX)s/tmp/%(program_name)s,%(ENV_XXXX)s/logs/%(program_name)s

will create the separate logs and tmp directory for every program
