### PR TITLE
Fix remaining Python 3 compatibility issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.pyc
 *.pyo
 *.swp
+*.pss
 .DS_Store
 .coverage
 .eggs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
           env: TOXENV=py36
 
 install:
-    - travis_retry pip install virtualenv tox
+    - travis_retry pip install virtualenv tox pexpect
 
 script:
     - travis_retry tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,8 @@ matrix:
           env: TOXENV=cover3
         - python: 3.6
           env: TOXENV=docs
-        - python: 2.6
-          env: TOXENV=py26
         - python: 2.7
           env: TOXENV=py27
-        - python: 3.2
-          env: TOXENV=py32
-        - python: 3.3
-          env: TOXENV=py33
         - python: 3.4
           env: TOXENV=py34
         - python: 3.5
@@ -26,8 +20,7 @@ matrix:
           env: TOXENV=py36
 
 install:
-    # "virtualenv<14.0.0" is needed for Python 3.2 compat
-    - travis_retry pip install "virtualenv<14.0.0" tox
+    - travis_retry pip install virtualenv tox
 
 script:
     - travis_retry tox

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,9 +2,12 @@
 -----------------------------
 
 - Support for Python 3 has been added.  On Python 3, Supervisor requires
-  Python 3.4 or later.
+  Python 3.4 or later.  Many thanks to Vinay Sajip, Scott Maxwell, Palm Kevin,
+  Tres Seaver, and Marc Abramowitz who all made major contributions to the
+  Python 3 porting effort.  Thanks also to all contributors who submitted
+  issue reports and patches towards this effort.
 
-- Support for Python 2.4, 2.5, and 2.6 has been dropped.  On Python 2, 
+- Support for Python 2.4, 2.5, and 2.6 has been dropped.  On Python 2,
   Supervisor now requires Python 2.7.
 
 - The ``supervisor`` package is no longer a namespace package.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,10 +2,10 @@
 -----------------------------
 
 - Support for Python 3 has been added.  On Python 3, Supervisor requires
-  Python 3.2 or later.
+  Python 3.4 or later.
 
-- Support for Python 2.4 and 2.5 has been dropped.  On Python 2, Supervisor
-  now requires Python 2.6 or later.
+- Support for Python 2.4, 2.5, and 2.6 has been dropped.  On Python 2, 
+  Supervisor now requires Python 2.7.
 
 - The ``supervisor`` package is no longer a namespace package.
 

--- a/README.rst
+++ b/README.rst
@@ -22,8 +22,8 @@ It may also have regressions on Python 2 as a result of attempts to
 add Python 3 support.  Help from developers with Python 3 porting
 experience is needed.  **Do not use this branch on any production system.**
 
-Supervisor 4.0 (unreleased) is planned to work under Python 2 version 2.6
-or greater and Python 3 version 3.2 or greater.  See note above about the
+Supervisor 4.0 (unreleased) is planned to work under Python 3 version 3.4
+or greater and on Python 2 version 2.7.  See note above about the
 current state of Python 3 support.
 
 Documentation

--- a/README.rst
+++ b/README.rst
@@ -13,15 +13,6 @@ likely work fine on most UNIX systems.
 
 Supervisor will not run at all under any version of Windows.
 
-**Supervisor does not work on Python 3.**  This is the master branch,
-which has work-in-progress support for Python 3.  Supervisor is very likely
-to crash, cause subprocesses to hang, or otherwise behave unexpectedly
-when run on Python 3.  See
-`issues running Supervisor on Python 3 <https://github.com/Supervisor/supervisor/labels/python%203>`_.
-It may also have regressions on Python 2 as a result of attempts to
-add Python 3 support.  Help from developers with Python 3 porting
-experience is needed.  **Do not use this branch on any production system.**
-
 Supervisor 4.0 (unreleased) is planned to work under Python 3 version 3.4
 or greater and on Python 2 version 2.7.  See note above about the
 current state of Python 3 support.

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,10 @@ import sys
 
 py_version = sys.version_info[:2]
 
-if py_version < (2, 6):
-    raise RuntimeError('On Python 2, Supervisor requires Python 2.6 or later')
-elif (3, 0) < py_version < (3, 2):
-    raise RuntimeError('On Python 3, Supervisor requires Python 3.2 or later')
+if py_version < (2, 7):
+    raise RuntimeError('On Python 2, Supervisor requires Python 2.7 or later')
+elif (3, 0) < py_version < (3, 4):
+    raise RuntimeError('On Python 3, Supervisor requires Python 3.4 or later')
 
 requires = ['meld3 >= 1.0.0']
 tests_require = []
@@ -28,7 +28,7 @@ if py_version < (3, 3):
     tests_require.append('mock')
 
 testing_extras = tests_require + [
-    'pytest < 3.0.0', # >= 2.5.2 but < 3.0.0.  pytest 3.0.0 breaks python 3.2
+    'pytest', 
     'pytest-cov',
     ]
 

--- a/supervisor/childutils.py
+++ b/supervisor/childutils.py
@@ -3,6 +3,7 @@ import time
 
 from supervisor.compat import xmlrpclib
 from supervisor.compat import long
+from supervisor.compat import as_string
 
 from supervisor.xmlrpc import SupervisorTransport
 from supervisor.events import ProcessCommunicationEvent
@@ -58,7 +59,7 @@ class EventListenerProtocol:
         return headers, payload
 
     def ready(self, stdout=sys.stdout):
-        stdout.write(PEventListenerDispatcher.READY_FOR_EVENTS_TOKEN)
+        stdout.write(as_string(PEventListenerDispatcher.READY_FOR_EVENTS_TOKEN))
         stdout.flush()
 
     def ok(self, stdout=sys.stdout):
@@ -69,7 +70,7 @@ class EventListenerProtocol:
 
     def send(self, data, stdout=sys.stdout):
         resultlen = len(data)
-        result = '%s%s\n%s' % (PEventListenerDispatcher.RESULT_TOKEN_START,
+        result = '%s%s\n%s' % (as_string(PEventListenerDispatcher.RESULT_TOKEN_START),
                                str(resultlen),
                                data)
         stdout.write(result)

--- a/supervisor/compat.py
+++ b/supervisor/compat.py
@@ -14,6 +14,10 @@ if PY3: # pragma: no cover
     def as_bytes(s): return s if isinstance(s,bytes) else s.encode('utf8')
     def as_string(s): return s if isinstance(s,str) else s.decode('utf8')
 
+    def is_text_stream(stream):
+        import _io
+        return isinstance(stream, _io._TextIOBase)
+
 else: # pragma: no cover
     long = long
     raw_input = raw_input
@@ -21,6 +25,18 @@ else: # pragma: no cover
     basestring = basestring
     def as_bytes(s): return s if isinstance(s, str) else s.encode('utf-8')
     def as_string(s): return s if isinstance(s, unicode) else s.decode('utf-8')
+
+    def is_text_stream(stream):
+        # TODO sort out for Python 2.4, 2.5 and 2.6 when a stream is
+        # opened using plain open() or codecs.open() rather than io.open()
+        if isinstance(stream, file):
+            return 'b' not in stream.mode
+        try:
+            import _io
+            return isinstance(stream, _io._TextIOBase)
+        except ImportError:
+            import io
+            return isinstance(stream, io.TextIOWrapper)
 
 def total_ordering(cls): # pragma: no cover
     """Class decorator that fills in missing ordering methods"""

--- a/supervisor/events.py
+++ b/supervisor/events.py
@@ -1,10 +1,11 @@
 from supervisor.states import getProcessStateDescription
+from supervisor.compat import as_string
 
 callbacks = []
 
 def subscribe(type, callback):
     callbacks.append((type, callback))
-    
+
 def notify(event):
     for type, callback in callbacks:
         if isinstance(event, type):
@@ -25,16 +26,22 @@ class ProcessLogEvent(Event):
         self.pid = pid
         self.data = data
 
-    def __str__(self):
+    def payload(self):
         groupname = ''
         if self.process.group is not None:
             groupname = self.process.group.config.name
-        return 'processname:%s groupname:%s pid:%s channel:%s\n%s' % (
-            self.process.config.name,
-            groupname,
-            self.pid,
-            self.channel,
-            self.data)
+        try:
+            data = as_string(self.data)
+        except UnicodeDecodeError:
+            data = 'Undecodable: %r' % self.data
+        # On Python 2, stuff needs to be in Unicode before invoking the
+        # % operator, otherwise implicit encodings to ASCII can cause
+        # failures
+        fmt = as_string('processname:%s groupname:%s pid:%s channel:%s\n%s')
+        result = fmt % (as_string(self.process.config.name),
+                        as_string(groupname), self.pid,
+                        as_string(self.channel), data)
+        return result
 
 class ProcessLogStdoutEvent(ProcessLogEvent):
     channel = 'stdout'
@@ -45,23 +52,27 @@ class ProcessLogStderrEvent(ProcessLogEvent):
 class ProcessCommunicationEvent(Event):
     """ Abstract """
     # event mode tokens
-    BEGIN_TOKEN = '<!--XSUPERVISOR:BEGIN-->'
-    END_TOKEN   = '<!--XSUPERVISOR:END-->'
+    BEGIN_TOKEN = b'<!--XSUPERVISOR:BEGIN-->'
+    END_TOKEN   = b'<!--XSUPERVISOR:END-->'
 
     def __init__(self, process, pid, data):
         self.process = process
         self.pid = pid
         self.data = data
 
-    def __str__(self):
+    def payload(self):
         groupname = ''
         if self.process.group is not None:
             groupname = self.process.group.config.name
+        try:
+            data = as_string(self.data)
+        except UnicodeDecodeError:
+            data = 'Undecodable: %r' % self.data
         return 'processname:%s groupname:%s pid:%s\n%s' % (
             self.process.config.name,
             groupname,
             self.pid,
-            self.data)
+            data)
 
 class ProcessCommunicationStdoutEvent(ProcessCommunicationEvent):
     channel = 'stdout'
@@ -74,12 +85,12 @@ class RemoteCommunicationEvent(Event):
         self.type = type
         self.data = data
 
-    def __str__(self):
+    def payload(self):
         return 'type:%s\n%s' % (self.type, self.data)
 
 class SupervisorStateChangeEvent(Event):
     """ Abstract class """
-    def __str__(self):
+    def payload(self):
         return ''
 
 class SupervisorRunningEvent(SupervisorStateChangeEvent):
@@ -88,7 +99,7 @@ class SupervisorRunningEvent(SupervisorStateChangeEvent):
 class SupervisorStoppingEvent(SupervisorStateChangeEvent):
     pass
 
-class EventRejectedEvent: # purposely does not subclass Event 
+class EventRejectedEvent: # purposely does not subclass Event
     def __init__(self, process, event):
         self.process = process
         self.event = event
@@ -105,7 +116,7 @@ class ProcessStateEvent(Event):
         # us, we stash the values at the time the event was sent
         self.extra_values = self.get_extra_values()
 
-    def __str__(self):
+    def payload(self):
         groupname = ''
         if self.process.group is not None:
             groupname = self.process.group.config.name
@@ -153,7 +164,8 @@ class ProcessStateStoppedEvent(ProcessStateEvent):
 class ProcessGroupEvent(Event):
     def __init__(self, group):
         self.group = group
-    def __str__(self):
+
+    def payload(self):
         return 'groupname:%s\n' % self.group
 
 class ProcessGroupAddedEvent(ProcessGroupEvent):
@@ -168,7 +180,7 @@ class TickEvent(Event):
         self.when = when
         self.supervisord = supervisord
 
-    def __str__(self):
+    def payload(self):
         return 'when:%s' % self.when
 
 class Tick5Event(TickEvent):
@@ -198,7 +210,7 @@ class EventTypes:
     PROCESS_COMMUNICATION_STDERR = ProcessCommunicationStderrEvent
     PROCESS_LOG = ProcessLogEvent
     PROCESS_LOG_STDOUT = ProcessLogStdoutEvent
-    PROCESS_LOG_STDERR = ProcessLogStderrEvent     
+    PROCESS_LOG_STDERR = ProcessLogStderrEvent
     REMOTE_COMMUNICATION = RemoteCommunicationEvent
     SUPERVISOR_STATE_CHANGE = SupervisorStateChangeEvent # abstract
     SUPERVISOR_STATE_CHANGE_RUNNING = SupervisorRunningEvent

--- a/supervisor/http.py
+++ b/supervisor/http.py
@@ -15,6 +15,7 @@ except ImportError:  # Windows
 from supervisor.compat import urllib
 from supervisor.compat import sha1
 from supervisor.compat import as_bytes
+from supervisor.compat import as_string
 from supervisor.medusa import asyncore_25 as asyncore
 from supervisor.medusa import http_date
 from supervisor.medusa import http_server
@@ -49,15 +50,16 @@ class deferring_chunked_producer:
             if data is NOT_DONE_YET:
                 return NOT_DONE_YET
             elif data:
-                return '%x\r\n%s\r\n' % (len(data), data)
+                s = '%x' % len(data)
+                return as_bytes(s) + b'\r\n' + data + b'\r\n'
             else:
                 self.producer = None
                 if self.footers:
-                    return '\r\n'.join(['0'] + self.footers) + '\r\n\r\n'
+                    return b'\r\n'.join([b'0'] + self.footers) + b'\r\n\r\n'
                 else:
-                    return '0\r\n\r\n'
+                    return b'0\r\n\r\n'
         else:
-            return ''
+            return b''
 
 class deferring_composite_producer:
     """combine a fifo of producers into one"""
@@ -76,7 +78,7 @@ class deferring_composite_producer:
             else:
                 self.producers.pop(0)
         else:
-            return ''
+            return b''
 
 
 class deferring_globbing_producer:
@@ -88,7 +90,7 @@ class deferring_globbing_producer:
 
     def __init__ (self, producer, buffer_size=1<<16):
         self.producer = producer
-        self.buffer = ''
+        self.buffer = b''
         self.buffer_size = buffer_size
         self.delay = 0.1
 
@@ -105,7 +107,7 @@ class deferring_globbing_producer:
             else:
                 break
         r = self.buffer
-        self.buffer = ''
+        self.buffer = b''
         return r
 
 
@@ -134,7 +136,7 @@ class deferring_hooked_producer:
                 self.bytes += len(result)
             return result
         else:
-            return ''
+            return b''
 
 
 class deferring_http_request(http_server.http_request):
@@ -350,13 +352,6 @@ class deferring_http_channel(http_server.http_channel):
             else:
                 return False
 
-        # It is possible that self.ac_out_buffer is equal b''
-        # and in Python3 b'' is not equal ''. This cause
-        # http_server.http_channel.writable(self) is always True.
-        # To avoid this case, we need to force self.ac_out_buffer = ''
-        if len(self.ac_out_buffer) == 0:
-            self.ac_out_buffer = ''
-
         return http_server.http_channel.writable(self)
 
     def refill_buffer (self):
@@ -371,7 +366,7 @@ class deferring_http_channel(http_server.http_channel):
                         self.producer_fifo.pop()
                         self.close()
                     return
-                elif isinstance(p, str):
+                elif isinstance(p, bytes):
                     self.producer_fifo.pop()
                     self.ac_out_buffer += p
                     return
@@ -383,11 +378,7 @@ class deferring_http_channel(http_server.http_channel):
                     return
 
                 elif data:
-                    try:
-                        self.ac_out_buffer = self.ac_out_buffer + data
-                    except TypeError:
-                        self.ac_out_buffer = as_bytes(self.ac_out_buffer) + as_bytes(data)
-
+                    self.ac_out_buffer = self.ac_out_buffer + data
                     self.delay = False
                     return
                 else:
@@ -402,8 +393,11 @@ class deferring_http_channel(http_server.http_channel):
         if self.current_request:
             self.current_request.found_terminator()
         else:
-            header = self.in_buffer
-            self.in_buffer = ''
+            # we convert the header to text to facilitate processing.
+            # some of the underlying APIs (such as splitquery)
+            # expect text rather than bytes.
+            header = as_string(self.in_buffer)
+            self.in_buffer = b''
             lines = header.split('\r\n')
 
             # --------------------------------------------------
@@ -431,12 +425,12 @@ class deferring_http_channel(http_server.http_channel):
             rpath, rquery = http_server.splitquery(uri)
             if '%' in rpath:
                 if rquery:
-                    uri = http_server.unquote (rpath) + '?' + rquery
+                    uri = http_server.unquote(rpath) + '?' + rquery
                 else:
-                    uri = http_server.unquote (rpath)
+                    uri = http_server.unquote(rpath)
 
-            r = deferring_http_request (self, request, command, uri, version,
-                                         header)
+            r = deferring_http_request(self, request, command, uri, version,
+                                       header)
             self.request_counter.increment()
             self.server.total_requests.increment()
 
@@ -661,7 +655,7 @@ class tail_f_producer:
             newsz = self._fsize()
         except (OSError, ValueError):
             # file descriptor was closed
-            return ''
+            return b''
         bytes_added = newsz - self.sz
         if bytes_added < 0:
             self.sz = 0

--- a/supervisor/http_client.py
+++ b/supervisor/http_client.py
@@ -9,9 +9,9 @@ from supervisor.compat import as_string
 from supervisor.compat import encodestring
 from supervisor.medusa import asynchat_25 as asynchat
 
-CR="\x0d"
-LF="\x0a"
-CRLF=CR+LF
+CR = b'\x0d'
+LF = b'\x0a'
+CRLF = CR+LF
 
 class Listener(object):
 
@@ -28,6 +28,10 @@ class Listener(object):
         pass
 
     def feed(self, url, data):
+        try:
+            data = as_string(data)
+        except UnicodeDecodeError:
+            data = 'Undecodable: %r' % data
         sys.stdout.write(data)
         sys.stdout.flush()
 
@@ -46,7 +50,7 @@ class HTTPHandler(asynchat.async_chat):
         asynchat.async_chat.__init__(self, conn, map)
         self.listener = listener
         self.user_agent = 'Supervisor HTTP Client'
-        self.buffer = ''
+        self.buffer = b''
         self.set_terminator(CRLF)
         self.connected = 0
         self.part = self.status_line
@@ -139,21 +143,21 @@ class HTTPHandler(asynchat.async_chat):
         self.buffer = self.buffer + bytes
         if self.part==self.body:
             self.feed(self.buffer)
-            self.buffer = ''
+            self.buffer = b''
 
     def found_terminator(self):
         self.part()
-        self.buffer = ''
+        self.buffer = b''
 
     def ignore(self):
-        self.buffer = ''
+        self.buffer = b''
 
     def status_line(self):
         line = self.buffer
 
         version, status, reason = line.split(None, 2)
         status = int(status)
-        if not version.startswith('HTTP/'):
+        if not version.startswith(b'HTTP/'):
             raise ValueError(line)
 
         self.listener.status(self.url, status)
@@ -170,19 +174,19 @@ class HTTPHandler(asynchat.async_chat):
     def headers(self):
         line = self.buffer
         if not line:
-            if self.encoding=="chunked":
+            if self.encoding == b'chunked':
                 self.part = self.chunked_size
             else:
                 self.part = self.body
                 self.set_terminator(self.length)
         else:
-            name, value = line.split(":", 1)
+            name, value = line.split(b':', 1)
             if name and value:
                 name = name.lower()
                 value = value.strip()
-                if name=="transfer-encoding":
+                if name == b'transfer-encoding':
                     self.encoding = value
-                elif name=="content-length":
+                elif name == b'content-length':
                     self.length = int(value)
                 self.response_header(name, value)
 
@@ -218,6 +222,6 @@ class HTTPHandler(asynchat.async_chat):
         # http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.6.1
         # trailer        = *(entity-header CRLF)
         line = self.buffer
-        if line==CRLF:
+        if line == CRLF:
             self.done()
             self.close()

--- a/supervisor/medusa/asynchat_25.py
+++ b/supervisor/medusa/asynchat_25.py
@@ -49,6 +49,7 @@ you - by calling your self.found_terminator() method.
 import socket
 from supervisor.medusa import asyncore_25 as asyncore
 from supervisor.compat import long
+from supervisor.compat import as_bytes
 
 class async_chat (asyncore.dispatcher):
     """This is an abstract class.  You must derive from this class, and add
@@ -60,8 +61,8 @@ class async_chat (asyncore.dispatcher):
     ac_out_buffer_size      = 4096
 
     def __init__ (self, conn=None, map=None):
-        self.ac_in_buffer = ''
-        self.ac_out_buffer = ''
+        self.ac_in_buffer = b''
+        self.ac_out_buffer = b''
         self.producer_fifo = fifo()
         asyncore.dispatcher.__init__ (self, conn, map)
 
@@ -84,7 +85,6 @@ class async_chat (asyncore.dispatcher):
     # if found, transition to the next state.
 
     def handle_read (self):
-
         try:
             data = self.recv (self.ac_in_buffer_size)
         except socket.error:
@@ -104,13 +104,13 @@ class async_chat (asyncore.dispatcher):
             if not terminator:
                 # no terminator, collect it all
                 self.collect_incoming_data (self.ac_in_buffer)
-                self.ac_in_buffer = ''
+                self.ac_in_buffer = b''
             elif isinstance(terminator, int) or isinstance(terminator, long):
                 # numeric terminator
                 n = terminator
                 if lb < n:
                     self.collect_incoming_data (self.ac_in_buffer)
-                    self.ac_in_buffer = ''
+                    self.ac_in_buffer = b''
                     self.terminator -= lb
                 else:
                     self.collect_incoming_data (self.ac_in_buffer[:n])
@@ -147,7 +147,7 @@ class async_chat (asyncore.dispatcher):
                     else:
                         # no prefix, collect it all
                         self.collect_incoming_data (self.ac_in_buffer)
-                        self.ac_in_buffer = ''
+                        self.ac_in_buffer = b''
 
     def handle_write (self):
         self.initiate_send ()
@@ -156,7 +156,8 @@ class async_chat (asyncore.dispatcher):
         self.close()
 
     def push (self, data):
-        self.producer_fifo.push (simple_producer (data))
+        data = as_bytes(data)
+        self.producer_fifo.push(simple_producer(data))
         self.initiate_send()
 
     def push_with_producer (self, producer):
@@ -172,7 +173,7 @@ class async_chat (asyncore.dispatcher):
         # return len(self.ac_out_buffer) or len(self.producer_fifo) or (not self.connected)
         # this is about twice as fast, though not as clear.
         return not (
-                (self.ac_out_buffer == '') and
+                (self.ac_out_buffer == b'') and
                 self.producer_fifo.is_empty() and
                 self.connected
                 )
@@ -194,7 +195,7 @@ class async_chat (asyncore.dispatcher):
                         self.producer_fifo.pop()
                         self.close()
                     return
-                elif isinstance(p, str):
+                elif isinstance(p, bytes):
                     self.producer_fifo.pop()
                     self.ac_out_buffer += p
                     return
@@ -226,8 +227,8 @@ class async_chat (asyncore.dispatcher):
 
     def discard_buffers (self):
         # Emergencies only!
-        self.ac_in_buffer = ''
-        self.ac_out_buffer = ''
+        self.ac_in_buffer = b''
+        self.ac_out_buffer = b''
         while self.producer_fifo:
             self.producer_fifo.pop()
 
@@ -245,7 +246,7 @@ class simple_producer:
             return result
         else:
             result = self.data
-            self.data = ''
+            self.data = b''
             return result
 
 class fifo:

--- a/supervisor/medusa/asyncore_25.py
+++ b/supervisor/medusa/asyncore_25.py
@@ -346,7 +346,7 @@ class dispatcher:
                 # a closed connection is indicated by signaling
                 # a read condition, and having recv() return 0.
                 self.handle_close()
-                return ''
+                return b''
             else:
                 return data
         except socket.error as why:
@@ -449,7 +449,7 @@ class dispatcher_with_send(dispatcher):
 
     def __init__(self, sock=None, map=None):
         dispatcher.__init__(self, sock, map)
-        self.out_buffer = ''
+        self.out_buffer = b''
 
     def initiate_send(self):
         num_sent = dispatcher.send(self, self.out_buffer[:512])

--- a/supervisor/medusa/http_server.py
+++ b/supervisor/medusa/http_server.py
@@ -12,6 +12,8 @@ import socket
 import sys
 import time
 
+from supervisor.compat import as_bytes
+
 # async modules
 import supervisor.medusa.asyncore_25 as asyncore
 import supervisor.medusa.asynchat_25 as asynchat
@@ -89,8 +91,9 @@ class http_request:
 
     def build_reply_header (self):
         header_items = ['%s: %s' % item for item in self.reply_headers.items()]
-        return '\r\n'.join (
+        result = '\r\n'.join (
             [self.response(self.reply_code)] + header_items) + '\r\n\r\n'
+        return as_bytes(result)
 
     ####################################################
     # multiple reply header management
@@ -260,11 +263,13 @@ class http_request:
                     )
 
     def push (self, thing):
-        if type(thing) == type(''):
-            self.outgoing.append(producers.simple_producer(thing,
-              buffer_size=len(thing)))
-        else:
-            self.outgoing.append(thing)
+        # Sometimes, text gets pushed by XMLRPC logic for later
+        # processing.
+        if isinstance(thing, str):
+            thing = as_bytes(thing)
+        if isinstance(thing, bytes):
+            thing = producers.simple_producer(thing, buffer_size=len(thing))
+        self.outgoing.append(thing)
 
     def response (self, code=200):
         message = self.responses[code]
@@ -278,10 +283,11 @@ class http_request:
                 'code': code,
                 'message': message,
                 }
+        s = as_bytes(s)
         self['Content-Length'] = len(s)
         self['Content-Type'] = 'text/html'
         # make an error reply
-        self.push (s)
+        self.push(s)
         self.done()
 
     # can also be used for empty replies
@@ -471,8 +477,8 @@ class http_channel (asynchat.async_chat):
         asynchat.async_chat.__init__ (self, conn)
         self.server = server
         self.addr = addr
-        self.set_terminator ('\r\n\r\n')
-        self.in_buffer = ''
+        self.set_terminator (b'\r\n\r\n')
+        self.in_buffer = b''
         self.creation_time = int (time.time())
         self.last_used = self.creation_time
         self.check_maintenance()
@@ -559,8 +565,8 @@ class http_channel (asynchat.async_chat):
             self.current_request.found_terminator()
         else:
             header = self.in_buffer
-            self.in_buffer = ''
-            lines = header.split('\r\n')
+            self.in_buffer = b''
+            lines = header.split(b'\r\n')
 
             # --------------------------------------------------
             # crack the request header

--- a/supervisor/medusa/producers.py
+++ b/supervisor/medusa/producers.py
@@ -26,7 +26,7 @@ class simple_producer:
             return result
         else:
             result = self.data
-            self.data = ''
+            self.data = b''
             return result
 
 class scanning_producer:
@@ -47,7 +47,7 @@ class scanning_producer:
             self.pos += len(result)
             return result
         else:
-            return ''
+            return b''
 
 class lines_producer:
     """producer for a list of lines"""
@@ -74,7 +74,7 @@ class buffer_list_producer:
 
     def more (self):
         if self.index >= len(self.buffers):
-            return ''
+            return b''
         else:
             data = self.buffers[self.index]
             self.index += 1
@@ -92,14 +92,14 @@ class file_producer:
 
     def more (self):
         if self.done:
-            return ''
+            return b''
         else:
             data = self.file.read (self.out_buffer_size)
             if not data:
                 self.file.close()
                 del self.file
                 self.done = 1
-                return ''
+                return b''
             else:
                 return data
 
@@ -113,7 +113,7 @@ class file_producer:
 class output_producer:
     """Acts like an output file; suitable for capturing sys.stdout"""
     def __init__ (self):
-        self.data = ''
+        self.data = b''
 
     def write (self, data):
         lines = data.split('\n')
@@ -154,7 +154,7 @@ class composite_producer:
             else:
                 self.producers.pop(0)
         else:
-            return ''
+            return b''
 
 
 class globbing_producer:
@@ -166,7 +166,7 @@ class globbing_producer:
 
     def __init__ (self, producer, buffer_size=1<<16):
         self.producer = producer
-        self.buffer = ''
+        self.buffer = b''
         self.buffer_size = buffer_size
 
     def more (self):
@@ -177,7 +177,7 @@ class globbing_producer:
             else:
                 break
         r = self.buffer
-        self.buffer = ''
+        self.buffer = b''
         return r
 
 
@@ -231,15 +231,16 @@ class chunked_producer:
         if self.producer:
             data = self.producer.more()
             if data:
-                return '%x\r\n%s\r\n' % (len(data), data)
+                s = '%x' % len(data)
+                return as_bytes(s) + b'\r\n' + data + b'\r\n'
             else:
                 self.producer = None
                 if self.footers:
-                    return '\r\n'.join(['0'] + self.footers) + '\r\n\r\n'
+                    return b'\r\n'.join([b'0'] + self.footers) + b'\r\n\r\n'
                 else:
-                    return '0\r\n\r\n'
+                    return b'0\r\n\r\n'
         else:
-            return ''
+            return b''
 
 try:
     import zlib
@@ -265,7 +266,7 @@ class compressed_producer:
 
     def more (self):
         if self.producer:
-            cdata = ''
+            cdata = b''
             # feed until we get some output
             while not cdata:
                 data = self.producer.more()
@@ -276,7 +277,7 @@ class compressed_producer:
                     cdata = self.compressor.compress (data)
             return cdata
         else:
-            return ''
+            return b''
 
 class escaping_producer:
 
@@ -287,7 +288,7 @@ class escaping_producer:
         self.producer = producer
         self.esc_from = esc_from
         self.esc_to = esc_to
-        self.buffer = ''
+        self.buffer = b''
         self.find_prefix_at_end = find_prefix_at_end
 
     def more (self):
@@ -305,7 +306,7 @@ class escaping_producer:
                 return buffer[:-i]
             else:
                 # no prefix, return it all
-                self.buffer = ''
+                self.buffer = b''
                 return buffer
         else:
             return buffer

--- a/supervisor/medusa/text_socket.py
+++ b/supervisor/medusa/text_socket.py
@@ -40,6 +40,6 @@ if PY3:
             return sock, addr
 
     text_socket.__init__.__doc__ = bin_socket.__init__.__doc__
-
+    text_socket = bin_socket
 else:
     text_socket = bin_socket

--- a/supervisor/medusa/xmlrpc_handler.py
+++ b/supervisor/medusa/xmlrpc_handler.py
@@ -7,6 +7,8 @@
 
 VERSION = "$Id: xmlrpc_handler.py,v 1.6 2004/04/21 14:09:24 akuchling Exp $"
 
+from supervisor.compat import as_string
+
 import supervisor.medusa.http_server as http_server
 try:
     import xmlrpclib
@@ -83,8 +85,10 @@ class collector:
 
     def found_terminator (self):
         # set the terminator back to the default
-        self.request.channel.set_terminator ('\r\n\r\n')
-        self.handler.continue_request ("".join(self.data), self.request)
+        self.request.channel.set_terminator (b'\r\n\r\n')
+        # convert the data back to text for processing
+        data = as_string(b''.join(self.data))
+        self.handler.continue_request (data, self.request)
 
 if __name__ == '__main__':
 

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -1537,8 +1537,8 @@ class ServerOptions(Options):
         except OSError as why:
             if why.args[0] not in (errno.EWOULDBLOCK, errno.EBADF, errno.EINTR):
                 raise
-            data = ''
-        return as_string(data)
+            data = b''
+        return data
 
     def process_environment(self):
         os.environ.update(self.environment or {})
@@ -2073,7 +2073,7 @@ def tailFile(filename, offset, length):
                 length = 0
 
             if length == 0:
-                data = ''
+                data = b''
             else:
                 f.seek(offset)
                 data = f.read(length)

--- a/supervisor/supervisorctl.py
+++ b/supervisor/supervisorctl.py
@@ -34,6 +34,7 @@ from supervisor.compat import xmlrpclib
 from supervisor.compat import urlparse
 from supervisor.compat import unicode
 from supervisor.compat import raw_input
+from supervisor.compat import as_string
 
 from supervisor.medusa import asyncore_25 as asyncore
 
@@ -661,7 +662,7 @@ class DefaultControllerPlugin(ControllerPluginBase):
         supervisor = self.ctl.get_supervisor()
         all_infos = supervisor.getAllProcessInfo()
 
-        names = arg.split()
+        names = as_string(arg).split()
         if not names or "all" in names:
             matching_infos = all_infos
         else:

--- a/supervisor/supervisord.py
+++ b/supervisor/supervisord.py
@@ -36,6 +36,7 @@ import signal
 
 from supervisor.medusa import asyncore_25 as asyncore
 
+from supervisor.compat import as_string
 from supervisor.options import ServerOptions
 from supervisor.options import signame
 from supervisor import events
@@ -141,7 +142,7 @@ class Supervisor:
             # throttle 'waiting for x to die' reports
             now = time.time()
             if now > (self.lastshutdownreport + 3): # every 3 secs
-                names = [ p.config.name for p in unstopped ]
+                names = [ as_string(p.config.name) for p in unstopped ]
                 namestr = ', '.join(names)
                 self.options.logger.info('waiting for %s to die' % namestr)
                 self.lastshutdownreport = now

--- a/supervisor/tests/base.py
+++ b/supervisor/tests/base.py
@@ -1136,7 +1136,7 @@ class DummyStream:
         self.error = error
         self.closed = False
         self.flushed = False
-        self.written = ''
+        self.written = b''
         self._fileno = fileno
     def close(self):
         if self.error:
@@ -1151,7 +1151,7 @@ class DummyStream:
             error = self.error
             self.error = None
             raise error
-        self.written += as_string(msg)
+        self.written += as_bytes(msg)
     def seek(self, num, whence=0):
         pass
     def tell(self):
@@ -1164,7 +1164,7 @@ class DummyEvent:
         if serial is not None:
             self.serial = serial
 
-    def __str__(self):
+    def payload(self):
         return 'dummy event'
 
 class DummyPoller:

--- a/supervisor/tests/fixtures/hello.sh
+++ b/supervisor/tests/fixtures/hello.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+n=0
+while :; do
+    let n=n+1
+    echo "The Øresund bridge ends in Malmö - $n"
+    sleep 1;
+done

--- a/supervisor/tests/fixtures/issue-565.conf
+++ b/supervisor/tests/fixtures/issue-565.conf
@@ -1,0 +1,22 @@
+[supervisord]
+loglevel=info                ; log level; default info; others: debug,warn,trace
+logfile=/tmp/supervisord.log ; main log file; default $CWD/supervisord.log
+pidfile=/tmp/supervisord.pid ; supervisord pidfile; default supervisord.pid
+nodaemon=true                ; start in foreground if true; default false
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[unix_http_server]
+file=/tmp/supervisor.sock   ; the path to the socket file
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
+
+[program:hello]
+command=bash supervisor/tests/fixtures/hello.sh
+stdout_events_enabled=true
+
+[eventlistener:listener]
+command=python supervisor/tests/fixtures/listener.py
+events=PROCESS_LOG

--- a/supervisor/tests/fixtures/issue-638.conf
+++ b/supervisor/tests/fixtures/issue-638.conf
@@ -1,0 +1,17 @@
+[supervisord]
+loglevel=debug               ; log level; default info; others: debug,warn,trace
+logfile=/tmp/supervisord.log ; main log file; default $CWD/supervisord.log
+pidfile=/tmp/supervisord.pid ; supervisord pidfile; default supervisord.pid
+nodaemon=true                ; start in foreground if true; default false
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[unix_http_server]
+file=/tmp/supervisor.sock   ; the path to the socket file
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
+
+[program:produce-unicode-error]
+command=echo -e "\x88"

--- a/supervisor/tests/fixtures/issue-663.conf
+++ b/supervisor/tests/fixtures/issue-663.conf
@@ -14,5 +14,5 @@ port = 127.0.0.1:9001
 serverurl = http://127.0.0.1:9001
 
 [eventlistener:listener]
-command=python /home/vinay/Documents/listener.py
+command=python supervisor/tests/fixtures/listener.py
 events=TICK_5

--- a/supervisor/tests/fixtures/issue-663.conf
+++ b/supervisor/tests/fixtures/issue-663.conf
@@ -1,0 +1,18 @@
+[supervisord]
+loglevel=debug
+logfile=/tmp/supervisord.log
+pidfile=/tmp/supervisord.pid
+nodaemon=true
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[inet_http_server]
+port = 127.0.0.1:9001
+
+[supervisorctl]
+serverurl = http://127.0.0.1:9001
+
+[eventlistener:listener]
+command=python /home/vinay/Documents/listener.py
+events=TICK_5

--- a/supervisor/tests/fixtures/issue-664.conf
+++ b/supervisor/tests/fixtures/issue-664.conf
@@ -1,0 +1,17 @@
+[supervisord]
+loglevel=debug
+logfile=/tmp/supervisord.log
+pidfile=/tmp/supervisord.pid
+nodaemon=true
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[inet_http_server]
+port = 127.0.0.1:9001
+
+[supervisorctl]
+serverurl = http://127.0.0.1:9001
+
+[program:test_öäü]
+command = /bin/cat

--- a/supervisor/tests/fixtures/issue-836.conf
+++ b/supervisor/tests/fixtures/issue-836.conf
@@ -1,0 +1,17 @@
+[supervisord]
+loglevel = debug
+logfile=/tmp/supervisord.log
+pidfile=/tmp/supervisord.pid
+nodaemon = true
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[inet_http_server]
+port = 127.0.0.1:9001
+
+[supervisorctl]
+serverurl = http://127.0.0.1:9001
+
+[program:cat]
+command = /bin/cat

--- a/supervisor/tests/fixtures/listener.py
+++ b/supervisor/tests/fixtures/listener.py
@@ -1,0 +1,38 @@
+
+import sys
+
+def write_and_flush(stream, s):
+    stream.write(s)
+    stream.flush()
+
+def write_stdout(s):
+    # only eventlistener protocol messages may be sent to stdout
+    sys.stdout.write(s)
+    sys.stdout.flush()
+
+def write_stderr(s):
+    sys.stderr.write(s)
+    sys.stderr.flush()
+
+def main():
+    stdin = sys.stdin
+    stdout = sys.stdout
+    stderr = sys.stderr
+    while True:
+        # transition from ACKNOWLEDGED to READY
+        write_and_flush(stdout, 'READY\n')
+
+        # read header line and print it to stderr
+        line = stdin.readline()
+        write_and_flush(stderr, line)
+
+        # read event payload and print it to stderr
+        headers = dict([ x.split(':') for x in line.split() ])
+        data = stdin.read(int(headers['len']))
+        write_and_flush(stderr, data)
+
+        # transition from READY to ACKNOWLEDGED
+        write_and_flush(stdout, 'RESULT 2\nOK')
+
+if __name__ == '__main__':
+    main()

--- a/supervisor/tests/test_childutils.py
+++ b/supervisor/tests/test_childutils.py
@@ -1,7 +1,9 @@
+from io import BytesIO
 import sys
 import time
 import unittest
 from supervisor.compat import StringIO
+from supervisor.compat import as_string
 
 class ChildUtilsTests(unittest.TestCase):
     def test_getRPCInterface(self):
@@ -49,23 +51,23 @@ class ChildUtilsTests(unittest.TestCase):
 class TestProcessCommunicationsProtocol(unittest.TestCase):
     def test_send(self):
         from supervisor.childutils import pcomm
-        stdout = StringIO()
-        pcomm.send('hello', stdout)
+        stdout = BytesIO()
+        pcomm.send(b'hello', stdout)
         from supervisor.events import ProcessCommunicationEvent
         begin = ProcessCommunicationEvent.BEGIN_TOKEN
         end = ProcessCommunicationEvent.END_TOKEN
-        self.assertEqual(stdout.getvalue(), '%s%s%s' % (begin, 'hello', end))
+        self.assertEqual(stdout.getvalue(), begin + b'hello' + end)
 
     def test_stdout(self):
         from supervisor.childutils import pcomm
         old = sys.stdout
         try:
-            io = sys.stdout = StringIO()
-            pcomm.stdout('hello')
+            io = sys.stdout = BytesIO()
+            pcomm.stdout(b'hello')
             from supervisor.events import ProcessCommunicationEvent
             begin = ProcessCommunicationEvent.BEGIN_TOKEN
             end = ProcessCommunicationEvent.END_TOKEN
-            self.assertEqual(io.getvalue(), '%s%s%s' % (begin, 'hello', end))
+            self.assertEqual(io.getvalue(), begin + b'hello' + end)
         finally:
             sys.stdout = old
 
@@ -73,12 +75,12 @@ class TestProcessCommunicationsProtocol(unittest.TestCase):
         from supervisor.childutils import pcomm
         old = sys.stderr
         try:
-            io = sys.stderr = StringIO()
-            pcomm.stderr('hello')
+            io = sys.stderr = BytesIO()
+            pcomm.stderr(b'hello')
             from supervisor.events import ProcessCommunicationEvent
             begin = ProcessCommunicationEvent.BEGIN_TOKEN
             end = ProcessCommunicationEvent.END_TOKEN
-            self.assertEqual(io.getvalue(), '%s%s%s' % (begin, 'hello', end))
+            self.assertEqual(io.getvalue(), begin + b'hello' + end)
         finally:
             sys.stderr = old
 
@@ -100,7 +102,7 @@ class TestEventListenerProtocol(unittest.TestCase):
     def test_token(self):
         from supervisor.childutils import listener
         from supervisor.dispatchers import PEventListenerDispatcher
-        token = PEventListenerDispatcher.READY_FOR_EVENTS_TOKEN
+        token = as_string(PEventListenerDispatcher.READY_FOR_EVENTS_TOKEN)
         stdout = StringIO()
         listener.ready(stdout)
         self.assertEqual(stdout.getvalue(), token)
@@ -108,7 +110,7 @@ class TestEventListenerProtocol(unittest.TestCase):
     def test_ok(self):
         from supervisor.childutils import listener
         from supervisor.dispatchers import PEventListenerDispatcher
-        begin = PEventListenerDispatcher.RESULT_TOKEN_START
+        begin = as_string(PEventListenerDispatcher.RESULT_TOKEN_START)
         stdout = StringIO()
         listener.ok(stdout)
         self.assertEqual(stdout.getvalue(), begin + '2\nOK')
@@ -116,7 +118,7 @@ class TestEventListenerProtocol(unittest.TestCase):
     def test_fail(self):
         from supervisor.childutils import listener
         from supervisor.dispatchers import PEventListenerDispatcher
-        begin = PEventListenerDispatcher.RESULT_TOKEN_START
+        begin = as_string(PEventListenerDispatcher.RESULT_TOKEN_START)
         stdout = StringIO()
         listener.fail(stdout)
         self.assertEqual(stdout.getvalue(), begin + '4\nFAIL')
@@ -124,7 +126,7 @@ class TestEventListenerProtocol(unittest.TestCase):
     def test_send(self):
         from supervisor.childutils import listener
         from supervisor.dispatchers import PEventListenerDispatcher
-        begin = PEventListenerDispatcher.RESULT_TOKEN_START
+        begin = as_string(PEventListenerDispatcher.RESULT_TOKEN_START)
         stdout = StringIO()
         msg = 'the body data ya fool\n'
         listener.send(msg, stdout)

--- a/supervisor/tests/test_end_to_end.py
+++ b/supervisor/tests/test_end_to_end.py
@@ -1,0 +1,114 @@
+# ~*~ coding: utf-8 ~*~
+from __future__ import unicode_literals
+
+import sys
+import signal
+import unittest
+
+try:
+    from xmlrpc.client import ServerProxy
+except ImportError:
+    from xmlrpclib import ServerProxy
+
+try:
+    import pexpect
+except ImportError:
+    pexpect = None
+
+
+class TestEndToEnd(unittest.TestCase):
+
+    @unittest.skipUnless(pexpect, 'This test needs the pexpect library')
+    def test_issue_565(self):
+        args = '-m supervisor.supervisord -c supervisor/tests/fixtures/issue-565.conf'.split()
+        supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
+        self.addCleanup(supervisord.kill, signal.SIGINT)
+        supervisord.expect_exact('success: hello entered RUNNING state')
+
+        args = '-m supervisor.supervisorctl -c supervisor/tests/fixtures/issue-565.conf tail -f hello'.split()
+        supervisorctl = pexpect.spawn(sys.executable, args, encoding='utf-8')
+        self.addCleanup(supervisorctl.kill, signal.SIGINT)
+
+        for i in range(1, 4):
+            line = 'The Øresund bridge ends in Malmö - %d' % i
+            supervisorctl.expect_exact(line, timeout=2)
+
+    @unittest.skipUnless(pexpect, 'This test needs the pexpect library')
+    def test_issue_638(self):
+        args = '-m supervisor.supervisord -c supervisor/tests/fixtures/issue-638.conf'.split()
+        supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
+        self.addCleanup(supervisord.kill, signal.SIGINT)
+        is_py2 = sys.version_info[0] < 3
+        if is_py2:
+            b_prefix = ''
+        else:
+            b_prefix = 'b'
+        supervisord.expect_exact(r"Undecodable: %s'\x88\n'" % b_prefix, timeout=2)
+        supervisord.expect('received SIGCH?LD indicating a child quit', timeout=5)
+        if is_py2:
+            # need to investigate why this message is only printed under 2.x
+            supervisord.expect_exact('gave up: produce-unicode-error entered FATAL state, '
+                                     'too many start retries too quickly', timeout=10)
+
+    @unittest.skipUnless(pexpect, 'This test needs the pexpect library')
+    def test_issue_663(self):
+        args = '-m supervisor.supervisord -c supervisor/tests/fixtures/issue-663.conf'.split()
+        supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
+        self.addCleanup(supervisord.kill, signal.SIGINT)
+        for i in range(2):
+            supervisord.expect_exact('OKREADY', timeout=10)
+            supervisord.expect_exact('BUSY -> ACKNOWLEDGED', timeout=2)
+
+    @unittest.skipUnless(pexpect, 'This test needs the pexpect library')
+    def test_issue_664(self):
+        args = '-m supervisor.supervisord -c supervisor/tests/fixtures/issue-664.conf'.split()
+        supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
+        self.addCleanup(supervisord.kill, signal.SIGINT)
+        supervisord.expect_exact('test_öäü entered RUNNING state', timeout=10)
+        args = '-m supervisor.supervisorctl -c supervisor/tests/fixtures/issue-664.conf status'.split()
+        supervisorctl = pexpect.spawn(sys.executable, args, encoding='utf-8')
+        self.addCleanup(supervisorctl.kill, signal.SIGINT)
+        try:
+            supervisorctl.expect('test_öäü\s+RUNNING', timeout=5)
+            seen = True
+        except pexpect.ExceptionPexpect:
+            seen = False
+        self.assertTrue(seen)
+
+    @unittest.skipUnless(pexpect, 'This test needs the pexpect library')
+    def test_issue_835(self):
+        args = '-m supervisor.supervisord -c supervisor/tests/fixtures/issue-836.conf'.split()
+        supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
+        self.addCleanup(supervisord.kill, signal.SIGINT)
+        supervisord.expect_exact('cat entered RUNNING state', timeout=10)
+        server = ServerProxy('http://127.0.0.1:9001/RPC2')
+        for s in ('The Øresund bridge ends in Malmö', 'hello'):
+            result = server.supervisor.sendProcessStdin('cat', s)
+            self.assertTrue(result)
+            supervisord.expect_exact(s, timeout=5)
+        server('close')()
+
+    @unittest.skipUnless(pexpect, 'This test needs the pexpect library')
+    def test_issue_836(self):
+        args = '-m supervisor.supervisord -c supervisor/tests/fixtures/issue-836.conf'.split()
+        supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
+        self.addCleanup(supervisord.kill, signal.SIGINT)
+        supervisord.expect_exact('cat entered RUNNING state', timeout=10)
+        args = '-m supervisor.supervisorctl -c supervisor/tests/fixtures/issue-836.conf fg cat'.split()
+        supervisorctl = pexpect.spawn(sys.executable, args, encoding='utf-8')
+        self.addCleanup(supervisorctl.kill, signal.SIGINT)
+
+        # TODO investigate - failure
+        try:
+            for s in ('Hi', 'Hello', 'The Øresund bridge ends in Malmö'):
+                supervisorctl.sendline(s)
+                supervisord.expect_exact(s, timeout=10)
+                supervisorctl.expect_exact(s) # echoed locally
+                supervisorctl.expect_exact(s) # sent back by supervisord
+            seen = True
+        except pexpect.ExceptionPexpect as e:
+            seen = False
+        self.assertTrue(seen)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/supervisor/tests/test_end_to_end.py
+++ b/supervisor/tests/test_end_to_end.py
@@ -94,7 +94,6 @@ class TestEndToEnd(unittest.TestCase):
         supervisorctl = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisorctl.kill, signal.SIGINT)
 
-        # TODO investigate - failure
         try:
             for s in ('Hi', 'Hello', 'The Øresund bridge ends in Malmö'):
                 supervisorctl.sendline(s)

--- a/supervisor/tests/test_end_to_end.py
+++ b/supervisor/tests/test_end_to_end.py
@@ -4,11 +4,7 @@ from __future__ import unicode_literals
 import sys
 import signal
 import unittest
-
-try:
-    from xmlrpc.client import ServerProxy
-except ImportError:
-    from xmlrpclib import ServerProxy
+from supervisor.compat import xmlrpclib
 
 try:
     import pexpect
@@ -81,7 +77,7 @@ class TestEndToEnd(unittest.TestCase):
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
         supervisord.expect_exact('cat entered RUNNING state', timeout=10)
-        server = ServerProxy('http://127.0.0.1:9001/RPC2')
+        server = xmlrpclib.ServerProxy('http://127.0.0.1:9001/RPC2')
         for s in ('The Øresund bridge ends in Malmö', 'hello'):
             result = server.supervisor.sendProcessStdin('cat', s)
             self.assertTrue(result)
@@ -106,7 +102,7 @@ class TestEndToEnd(unittest.TestCase):
                 supervisorctl.expect_exact(s) # echoed locally
                 supervisorctl.expect_exact(s) # sent back by supervisord
             seen = True
-        except pexpect.ExceptionPexpect as e:
+        except pexpect.ExceptionPexpect:
             seen = False
         self.assertTrue(seen)
 

--- a/supervisor/tests/test_end_to_end.py
+++ b/supervisor/tests/test_end_to_end.py
@@ -78,11 +78,13 @@ class TestEndToEnd(unittest.TestCase):
         self.addCleanup(supervisord.kill, signal.SIGINT)
         supervisord.expect_exact('cat entered RUNNING state', timeout=10)
         server = xmlrpclib.ServerProxy('http://127.0.0.1:9001/RPC2')
-        for s in ('The Øresund bridge ends in Malmö', 'hello'):
-            result = server.supervisor.sendProcessStdin('cat', s)
-            self.assertTrue(result)
-            supervisord.expect_exact(s, timeout=5)
-        server('close')()
+        try:
+            for s in ('The Øresund bridge ends in Malmö', 'hello'):
+                result = server.supervisor.sendProcessStdin('cat', s)
+                self.assertTrue(result)
+                supervisord.expect_exact(s, timeout=5)
+        finally:
+            server('close')()
 
     @unittest.skipUnless(pexpect, 'This test needs the pexpect library')
     def test_issue_836(self):

--- a/supervisor/tests/test_events.py
+++ b/supervisor/tests/test_events.py
@@ -273,7 +273,7 @@ class TestSerializations(unittest.TestCase):
             config = pconfig1
         process1.group = DummyGroup
         event = ProcessLogStdoutEvent(process1, 1, 'yo')
-        headers, payload = self._deserialize(str(event))
+        headers, payload = self._deserialize(event.payload())
         self.assertEqual(headers['processname'], 'process1', headers)
         self.assertEqual(headers['groupname'], 'process1', headers)
         self.assertEqual(headers['pid'], '1', headers)
@@ -288,7 +288,7 @@ class TestSerializations(unittest.TestCase):
             config = pconfig1
         process1.group = DummyGroup
         event = ProcessLogStderrEvent(process1, 1, 'yo')
-        headers, payload = self._deserialize(str(event))
+        headers, payload = self._deserialize(event.payload())
         self.assertEqual(headers['processname'], 'process1', headers)
         self.assertEqual(headers['groupname'], 'process1', headers)
         self.assertEqual(headers['pid'], '1', headers)
@@ -303,7 +303,7 @@ class TestSerializations(unittest.TestCase):
             config = pconfig1
         process1.group = DummyGroup
         event = ProcessCommunicationStdoutEvent(process1, 1, 'yo')
-        headers, payload = self._deserialize(str(event))
+        headers, payload = self._deserialize(event.payload())
         self.assertEqual(headers['processname'], 'process1', headers)
         self.assertEqual(headers['groupname'], 'process1', headers)
         self.assertEqual(headers['pid'], '1', headers)
@@ -318,7 +318,7 @@ class TestSerializations(unittest.TestCase):
         process1.group = DummyGroup
         from supervisor.events import ProcessCommunicationStderrEvent
         event = ProcessCommunicationStderrEvent(process1, 1, 'yo')
-        headers, payload = self._deserialize(str(event))
+        headers, payload = self._deserialize(event.payload())
         self.assertEqual(headers['processname'], 'process1', headers)
         self.assertEqual(headers['groupname'], 'process1', headers)
         self.assertEqual(headers['pid'], '1', headers)
@@ -327,21 +327,21 @@ class TestSerializations(unittest.TestCase):
     def test_remote_comm_event(self):
         from supervisor.events import RemoteCommunicationEvent
         event = RemoteCommunicationEvent('foo', 'bar')
-        headers, payload = self._deserialize(str(event))
+        headers, payload = self._deserialize(event.payload())
         self.assertEqual(headers['type'], 'foo', headers)
         self.assertEqual(payload, 'bar')
 
     def test_process_group_added_event(self):
         from supervisor.events import ProcessGroupAddedEvent
         event = ProcessGroupAddedEvent('foo')
-        headers, payload = self._deserialize(str(event))
+        headers, payload = self._deserialize(event.payload())
         self.assertEqual(headers['groupname'], 'foo')
         self.assertEqual(payload, '')
 
     def test_process_group_removed_event(self):
         from supervisor.events import ProcessGroupRemovedEvent
         event = ProcessGroupRemovedEvent('foo')
-        headers, payload = self._deserialize(str(event))
+        headers, payload = self._deserialize(event.payload())
         self.assertEqual(headers['groupname'], 'foo')
         self.assertEqual(payload, '')
 
@@ -360,7 +360,7 @@ class TestSerializations(unittest.TestCase):
             process1 = DummyProcess(pconfig1)
             process1.group = DummyGroup
             event = klass(process1, ProcessStates.STARTING)
-            headers, payload = self._deserialize(str(event))
+            headers, payload = self._deserialize(event.payload())
             self.assertEqual(len(headers), 3)
             self.assertEqual(headers['processname'], 'process1')
             self.assertEqual(headers['groupname'], 'process1')
@@ -384,7 +384,7 @@ class TestSerializations(unittest.TestCase):
             process1.group = DummyGroup
             process1.pid = 1
             event = klass(process1, ProcessStates.STARTING)
-            headers, payload = self._deserialize(str(event))
+            headers, payload = self._deserialize(event.payload())
             self.assertEqual(len(headers), 4)
             self.assertEqual(headers['processname'], 'process1')
             self.assertEqual(headers['groupname'], 'process1')
@@ -407,7 +407,7 @@ class TestSerializations(unittest.TestCase):
             process1 = DummyProcess(pconfig1)
             process1.group = DummyGroup
             event = klass(process1, ProcessStates.STARTING)
-            headers, payload = self._deserialize(str(event))
+            headers, payload = self._deserialize(event.payload())
             self.assertEqual(len(headers), 4)
             self.assertEqual(headers['processname'], 'process1')
             self.assertEqual(headers['groupname'], 'process1')
@@ -416,11 +416,11 @@ class TestSerializations(unittest.TestCase):
             self.assertEqual(payload, '')
             process1.backoff = 1
             event = klass(process1, ProcessStates.STARTING)
-            headers, payload = self._deserialize(str(event))
+            headers, payload = self._deserialize(event.payload())
             self.assertEqual(headers['tries'], '1')
             process1.backoff = 2
             event = klass(process1, ProcessStates.STARTING)
-            headers, payload = self._deserialize(str(event))
+            headers, payload = self._deserialize(event.payload())
             self.assertEqual(headers['tries'], '2')
 
     def test_process_state_exited_event_expected(self):
@@ -436,7 +436,7 @@ class TestSerializations(unittest.TestCase):
         event = events.ProcessStateExitedEvent(process1,
                                                ProcessStates.STARTING,
                                                expected=True)
-        headers, payload = self._deserialize(str(event))
+        headers, payload = self._deserialize(event.payload())
         self.assertEqual(len(headers), 5)
         self.assertEqual(headers['processname'], 'process1')
         self.assertEqual(headers['groupname'], 'process1')
@@ -458,7 +458,7 @@ class TestSerializations(unittest.TestCase):
         event = events.ProcessStateExitedEvent(process1,
                                                ProcessStates.STARTING,
                                                expected=False)
-        headers, payload = self._deserialize(str(event))
+        headers, payload = self._deserialize(event.payload())
         self.assertEqual(len(headers), 5)
         self.assertEqual(headers['processname'], 'process1')
         self.assertEqual(headers['groupname'], 'process1')
@@ -470,7 +470,7 @@ class TestSerializations(unittest.TestCase):
     def test_supervisor_sc_event(self):
         from supervisor import events
         event = events.SupervisorRunningEvent()
-        headers, payload = self._deserialize(str(event))
+        headers, payload = self._deserialize(event.payload())
         self.assertEqual(headers, {})
         self.assertEqual(payload, '')
 
@@ -482,7 +482,7 @@ class TestSerializations(unittest.TestCase):
             events.Tick3600Event,
             ):
             event = klass(1, 2)
-            headers, payload = self._deserialize(str(event))
+            headers, payload = self._deserialize(event.payload())
             self.assertEqual(headers, {'when':'1'})
             self.assertEqual(payload, '')
 

--- a/supervisor/tests/test_http.py
+++ b/supervisor/tests/test_http.py
@@ -122,15 +122,15 @@ class TailFProducerTests(unittest.TestCase):
         request = DummyRequest('/logtail/foo', None, None, None)
         from supervisor import http
         f = tempfile.NamedTemporaryFile()
-        f.write(as_bytes('a' * 80))
+        f.write(b'a' * 80)
         f.flush()
         producer = self._makeOne(request, f.name, 80)
         result = producer.more()
-        self.assertEqual(result, as_bytes('a' * 80))
-        f.write(as_bytes('w' * 100))
+        self.assertEqual(result, b'a' * 80)
+        f.write(as_bytes(b'w' * 100))
         f.flush()
         result = producer.more()
-        self.assertEqual(result, as_bytes('w' * 100))
+        self.assertEqual(result, b'w' * 100)
         result = producer.more()
         self.assertEqual(result, http.NOT_DONE_YET)
         f.truncate(0)
@@ -155,33 +155,33 @@ class TailFProducerTests(unittest.TestCase):
         f.flush()
         producer = self._makeOne(request, f.name, 80)
         result = producer.more()
-        self.assertEqual(result, as_bytes('a' * 80))
+        self.assertEqual(result, b'a' * 80)
         f.close()
         f2 = open(f.name, 'wb')
         try:
-            f2.write(as_bytes('b' * 80))
+            f2.write(as_bytes(b'b' * 80))
             f2.close()
             result = producer.more()
         finally:
             os.unlink(f2.name)
-        self.assertEqual(result, as_bytes('b' * 80))
+        self.assertEqual(result, b'b' * 80)
 
     def test_handle_more_follow_file_gone(self):
         request = DummyRequest('/logtail/foo', None, None, None)
         filename = tempfile.mktemp()
         with open(filename, 'wb') as f:
-            f.write(as_bytes('a' * 80))
+            f.write(b'a' * 80)
         try:
             producer = self._makeOne(request, f.name, 80)
         finally:
             os.unlink(f.name)
         result = producer.more()
-        self.assertEqual(result, as_bytes('a' * 80))
+        self.assertEqual(result, b'a' * 80)
         with open(filename, 'wb') as f:
-            f.write(as_bytes('b' * 80))
+            f.write(as_bytes(b'b' * 80))
         try:
             result = producer.more() # should open in new file
-            self.assertEqual(result, as_bytes('b' * 80))
+            self.assertEqual(result, b'b' * 80)
         finally:
              os.unlink(f.name)
 
@@ -199,28 +199,28 @@ class DeferringChunkedProducerTests(unittest.TestCase):
         self.assertEqual(producer.more(), NOT_DONE_YET)
 
     def test_more_string(self):
-        wrapped = DummyProducer('hello')
+        wrapped = DummyProducer(b'hello')
         producer = self._makeOne(wrapped)
-        self.assertEqual(producer.more(), '5\r\nhello\r\n')
+        self.assertEqual(producer.more(), b'5\r\nhello\r\n')
 
     def test_more_nodata(self):
         wrapped = DummyProducer()
-        producer = self._makeOne(wrapped, footers=['a', 'b'])
-        self.assertEqual(producer.more(), '0\r\na\r\nb\r\n\r\n')
+        producer = self._makeOne(wrapped, footers=[b'a', b'b'])
+        self.assertEqual(producer.more(), b'0\r\na\r\nb\r\n\r\n')
 
     def test_more_nodata_footers(self):
-        wrapped = DummyProducer('')
-        producer = self._makeOne(wrapped, footers=['a', 'b'])
-        self.assertEqual(producer.more(), '0\r\na\r\nb\r\n\r\n')
+        wrapped = DummyProducer(b'')
+        producer = self._makeOne(wrapped, footers=[b'a', b'b'])
+        self.assertEqual(producer.more(), b'0\r\na\r\nb\r\n\r\n')
 
     def test_more_nodata_nofooters(self):
-        wrapped = DummyProducer('')
+        wrapped = DummyProducer(b'')
         producer = self._makeOne(wrapped)
-        self.assertEqual(producer.more(), '0\r\n\r\n')
+        self.assertEqual(producer.more(), b'0\r\n\r\n')
 
     def test_more_noproducer(self):
         producer = self._makeOne(None)
-        self.assertEqual(producer.more(), '')
+        self.assertEqual(producer.more(), b'')
 
 class DeferringCompositeProducerTests(unittest.TestCase):
     def _getTargetClass(self):
@@ -241,12 +241,12 @@ class DeferringCompositeProducerTests(unittest.TestCase):
         producer = self._makeOne([wrapped1, wrapped2])
         self.assertEqual(producer.more(), 'hello')
         self.assertEqual(producer.more(), 'goodbye')
-        self.assertEqual(producer.more(), '')
+        self.assertEqual(producer.more(), b'')
 
     def test_more_nodata(self):
         wrapped = DummyProducer()
         producer = self._makeOne([wrapped])
-        self.assertEqual(producer.more(), '')
+        self.assertEqual(producer.more(), b'')
 
 class DeferringGlobbingProducerTests(unittest.TestCase):
     def _getTargetClass(self):
@@ -264,16 +264,16 @@ class DeferringGlobbingProducerTests(unittest.TestCase):
     def test_more_string(self):
         wrapped = DummyProducer('hello', 'there', 'guy')
         producer = self._makeOne(wrapped, buffer_size=1)
-        self.assertEqual(producer.more(), 'hello')
+        self.assertEqual(producer.more(), b'hello')
 
         wrapped = DummyProducer('hello', 'there', 'guy')
         producer = self._makeOne(wrapped, buffer_size=50)
-        self.assertEqual(producer.more(), 'hellothereguy')
+        self.assertEqual(producer.more(), b'hellothereguy')
 
     def test_more_nodata(self):
         wrapped = DummyProducer()
         producer = self._makeOne(wrapped)
-        self.assertEqual(producer.more(), '')
+        self.assertEqual(producer.more(), b'')
 
 class DeferringHookedProducerTests(unittest.TestCase):
     def _getTargetClass(self):
@@ -305,12 +305,12 @@ class DeferringHookedProducerTests(unittest.TestCase):
         def callback(bytes):
             L.append(bytes)
         producer = self._makeOne(wrapped, callback)
-        self.assertEqual(producer.more(), '')
+        self.assertEqual(producer.more(), b'')
         self.assertEqual(L, [0])
 
     def test_more_noproducer(self):
         producer = self._makeOne(None, None)
-        self.assertEqual(producer.more(), '')
+        self.assertEqual(producer.more(), b'')
 
 class DeferringHttpRequestTests(unittest.TestCase):
     def _getTargetClass(self):
@@ -676,7 +676,7 @@ class DummyProducer:
         if self.data:
             return self.data.pop(0)
         else:
-            return ''
+            return b''
 
 def test_suite():
     return unittest.findTestCases(sys.modules[__name__])

--- a/supervisor/tests/test_loggers.py
+++ b/supervisor/tests/test_loggers.py
@@ -99,28 +99,28 @@ class BareHandlerTests(HandlerTests, unittest.TestCase):
     def test_emit_gardenpath(self):
         stream = DummyStream()
         inst = self._makeOne(stream=stream)
-        record = self._makeLogRecord('foo')
+        record = self._makeLogRecord(b'foo')
         inst.emit(record)
         self.assertEqual(stream.flushed, True)
-        self.assertEqual(stream.written, 'foo')
+        self.assertEqual(stream.written, b'foo')
 
     def test_emit_unicode_error(self):
         stream = DummyStream(error=UnicodeError)
         inst = self._makeOne(stream=stream)
-        record = self._makeLogRecord('foo')
+        record = self._makeLogRecord(b'foo')
         inst.emit(record)
         self.assertEqual(stream.flushed, True)
-        self.assertEqual(stream.written, 'foo')
+        self.assertEqual(stream.written, b'foo')
 
     def test_emit_other_error(self):
-        stream = DummyStream(error=TypeError)
+        stream = DummyStream(error=ValueError)
         inst = self._makeOne(stream=stream)
         handled = []
         inst.handleError = lambda: handled.append(True)
-        record = self._makeLogRecord('foo')
+        record = self._makeLogRecord(b'foo')
         inst.emit(record)
         self.assertEqual(stream.flushed, False)
-        self.assertEqual(stream.written, '')
+        self.assertEqual(stream.written, b'')
 
 class FileHandlerTests(HandlerTests, unittest.TestCase):
     def _getTargetClass(self):
@@ -130,7 +130,7 @@ class FileHandlerTests(HandlerTests, unittest.TestCase):
     def test_ctor(self):
         handler = self._makeOne(self.filename)
         self.assertTrue(os.path.exists(self.filename), self.filename)
-        self.assertEqual(handler.mode, 'a')
+        self.assertEqual(handler.mode, 'ab')
         self.assertEqual(handler.baseFilename, self.filename)
         self.assertEqual(handler.stream.name, self.filename)
         handler.close()
@@ -190,15 +190,15 @@ class FileHandlerTests(HandlerTests, unittest.TestCase):
 
     def test_emit_ascii_noerror(self):
         handler = self._makeOne(self.filename)
-        record = self._makeLogRecord('hello!')
+        record = self._makeLogRecord(b'hello!')
         handler.emit(record)
         handler.close()
-        with open(self.filename, 'r') as f:
-            self.assertEqual(f.read(), 'hello!')
+        with open(self.filename, 'rb') as f:
+            self.assertEqual(f.read(), b'hello!')
 
     def test_emit_unicode_noerror(self):
         handler = self._makeOne(self.filename)
-        record = self._makeLogRecord(as_string(b'fi\xc3\xad'))
+        record = self._makeLogRecord(b'fi\xc3\xad')
         handler.emit(record)
         handler.close()
         with open(self.filename, 'rb') as f:
@@ -208,7 +208,7 @@ class FileHandlerTests(HandlerTests, unittest.TestCase):
         handler = self._makeOne(self.filename)
         handler.stream.close()
         handler.stream = DummyStream(error=OSError)
-        record = self._makeLogRecord('hello!')
+        record = self._makeLogRecord(b'hello!')
         try:
             old_stderr = sys.stderr
             dummy_stderr = DummyStream()
@@ -217,7 +217,7 @@ class FileHandlerTests(HandlerTests, unittest.TestCase):
         finally:
             sys.stderr = old_stderr
 
-        self.assertTrue(dummy_stderr.written.endswith('OSError\n'),
+        self.assertTrue(dummy_stderr.written.endswith(b'OSError\n'),
                         dummy_stderr.written)
 
 if os.path.exists('/dev/stdout'):
@@ -231,7 +231,7 @@ class StdoutTests(StdoutTestsBase):
         handler = self._makeOne('/dev/stdout')
         # Modes 'w' and 'a' have the same semantics when applied to
         # character device files and fifos.
-        self.assertTrue(handler.mode in ['w', 'a'], handler.mode)
+        self.assertTrue(handler.mode in ['wb', 'ab'], handler.mode)
         self.assertEqual(handler.baseFilename, '/dev/stdout')
         self.assertEqual(handler.stream.name, '/dev/stdout')
         handler.close()
@@ -244,14 +244,14 @@ class RotatingFileHandlerTests(FileHandlerTests):
 
     def test_ctor(self):
         handler = self._makeOne(self.filename)
-        self.assertEqual(handler.mode, 'a')
+        self.assertEqual(handler.mode, 'ab')
         self.assertEqual(handler.maxBytes, 512*1024*1024)
         self.assertEqual(handler.backupCount, 10)
         handler.close()
 
     def test_emit_does_rollover(self):
         handler = self._makeOne(self.filename, maxBytes=10, backupCount=2)
-        record = self._makeLogRecord('a' * 4)
+        record = self._makeLogRecord(b'a' * 4)
 
         handler.emit(record) # 4 bytes
         self.assertFalse(os.path.exists(self.filename + '.1'))
@@ -282,18 +282,18 @@ class RotatingFileHandlerTests(FileHandlerTests):
         self.assertTrue(os.path.exists(self.filename + '.1'))
         self.assertTrue(os.path.exists(self.filename + '.2'))
 
-        with open(self.filename, 'r') as f:
-            self.assertEqual(f.read(), 'a' * 4)
+        with open(self.filename, 'rb') as f:
+            self.assertEqual(f.read(), b'a' * 4)
 
-        with open(self.filename+'.1', 'r') as f:
-            self.assertEqual(f.read(), 'a' * 12)
+        with open(self.filename+'.1', 'rb') as f:
+            self.assertEqual(f.read(), b'a' * 12)
 
-        with open(self.filename+'.2', 'r') as f:
-            self.assertEqual(f.read(), 'a' * 12)
+        with open(self.filename+'.2', 'rb') as f:
+            self.assertEqual(f.read(), b'a' * 12)
 
     def test_current_logfile_removed(self):
         handler = self._makeOne(self.filename, maxBytes=6, backupCount=1)
-        record = self._makeLogRecord('a' * 4)
+        record = self._makeLogRecord(b'a' * 4)
 
         handler.emit(record) # 4 bytes
         self.assertTrue(os.path.exists(self.filename))
@@ -388,23 +388,23 @@ class BoundIOTests(unittest.TestCase):
         return klass(maxbytes, buf)
 
     def test_write_overflow(self):
-        io = self._makeOne(1, 'a')
-        io.write('b')
-        self.assertEqual(io.buf, 'b')
+        io = self._makeOne(1, b'a')
+        io.write(b'b')
+        self.assertEqual(io.buf, b'b')
 
     def test_getvalue(self):
-        io = self._makeOne(1, 'a')
-        self.assertEqual(io.getvalue(), 'a')
+        io = self._makeOne(1, b'a')
+        self.assertEqual(io.getvalue(), b'a')
 
     def test_clear(self):
-        io = self._makeOne(1, 'a')
+        io = self._makeOne(1, b'a')
         io.clear()
-        self.assertEqual(io.buf, '')
+        self.assertEqual(io.buf, b'')
 
     def test_close(self):
-        io = self._makeOne(1, 'a')
+        io = self._makeOne(1, b'a')
         io.close()
-        self.assertEqual(io.buf, '')
+        self.assertEqual(io.buf, b'')
 
 class LoggerTests(unittest.TestCase):
     def _getTargetClass(self):

--- a/supervisor/tests/test_xmlrpc.py
+++ b/supervisor/tests/test_xmlrpc.py
@@ -474,7 +474,7 @@ class SupervisorTransportTests(unittest.TestCase):
         self.assertEqual(dummy_conn.closed, True)
         self.assertEqual(dummy_conn.requestargs[0], 'POST')
         self.assertEqual(dummy_conn.requestargs[1], '/')
-        self.assertEqual(dummy_conn.requestargs[2], '')
+        self.assertEqual(dummy_conn.requestargs[2], b'')
         self.assertEqual(dummy_conn.requestargs[3]['Content-Length'], '0')
         self.assertEqual(dummy_conn.requestargs[3]['Content-Type'], 'text/xml')
         self.assertEqual(dummy_conn.requestargs[3]['Authorization'],
@@ -500,7 +500,7 @@ class SupervisorTransportTests(unittest.TestCase):
         self.assertEqual(dummy_conn.closed, False)
         self.assertEqual(dummy_conn.requestargs[0], 'POST')
         self.assertEqual(dummy_conn.requestargs[1], '/')
-        self.assertEqual(dummy_conn.requestargs[2], '')
+        self.assertEqual(dummy_conn.requestargs[2], b'')
         self.assertEqual(dummy_conn.requestargs[3]['Content-Length'], '0')
         self.assertEqual(dummy_conn.requestargs[3]['Content-Type'], 'text/xml')
         self.assertEqual(dummy_conn.requestargs[3]['Authorization'],

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,9 @@ envlist =
 
 [testenv]
 deps =
-    pytest
     meld3 >= 1.0.0
+    pytest
+    pexpect
     mock >= 0.5.0
 commands =
     py.test {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist =
-    cover,cover3,docs,py26,py27,py32,py33,py34,py35,py36
+    cover,cover3,docs,py27,py34,py35,py36
 
 [testenv]
 deps =
-    pytest < 3.0.0  # >= 2.5.2 but < 3.0.0.  pytest 3.0.0 breaks python 3.2
+    pytest
     meld3 >= 1.0.0
     mock >= 0.5.0
 commands =


### PR DESCRIPTION
This pull request applies a patch submitted by @vsajip that overhauls bytes/strings handling inside `supervisord` to fix all of the open Python 3 issues.  Test cases are included for all of those issues.

Closes #471
Closes #565
Closes #638
Closes #663
Closes #664
Closes #835
Closes #836
Closes #974

Thank you @vsajip!
