### PR TITLE
Add vim modeline to sample configuration file

### DIFF
--- a/supervisor/skel/sample.conf
+++ b/supervisor/skel/sample.conf
@@ -1,4 +1,5 @@
 ; Sample supervisor config file.
+; vim: set ft=dosini:
 ;
 ; For more information on the config file, please see:
 ; http://supervisord.org/configuration.html


### PR DESCRIPTION
Hi, my vim install did not recognise the file syntax properly so I think that adding a modeline is a good idea, it makes it much easier to see what parts are commented out.