### PR TITLE
Fix process state code in docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -229,7 +229,7 @@ Process Control
              'start':          1200361776,
              'stop':           0,
              'now':            1200361812,
-             'state':          1,
+             'state':          20,
              'statename':      'RUNNING',
              'spawnerr':       '',
              'exitstatus':     0,


### PR DESCRIPTION
The example of [getProcessInfo()](http://supervisord.org/api.html#supervisor.rpcinterface.SupervisorNamespaceRPCInterface.getProcessInfo) shows wrong state code for "RUNNING". It should be 20 as described in [Process States](http://supervisord.org/subprocess.html#process-states).

After a quick grep, I think this is the only mistake about process states.