### PR TITLE
Travis CI and Tox: Add Python 3.7 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,14 @@ matrix:
     include:
         - python: 2.7
           env: TOXENV=cover
-        - python: 3.6
+        - python: 3.7
           env: TOXENV=cover3
-        - python: 3.6
+          dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+          sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+        - python: 3.7
           env: TOXENV=docs
+          dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+          sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
         - python: 2.7
           env:
             - TOXENV=py27
@@ -26,6 +30,12 @@ matrix:
           env:
             - TOXENV=py36
             - END_TO_END=1
+        - python: 3.7
+          env:
+            - TOXENV=py37
+            - END_TO_END=1
+          dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+          sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
 
 install:
     - travis_retry pip install virtualenv tox pexpect

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    cover,cover3,docs,py27,py34,py35,py36
+    cover,cover3,docs,py27,py34,py35,py36,py37
 
 [testenv]
 deps =
@@ -21,7 +21,7 @@ deps =
     pytest-cov
 
 [testenv:cover3]
-basepython = python3.6
+basepython = python3.7
 commands =
     py.test --cov=supervisor --cov-report=term-missing --cov-report=xml {posargs}
 deps =


### PR DESCRIPTION
Python 3.7 on Travis CI configured in alignment with travis-ci/travis-ci#9069