### PR TITLE
Replace easy_install by pip installation method

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -10,32 +10,33 @@ Installing to A System With Internet Access
 If your system has internet access, you can get Supervisor
 installed in two ways:
 
-- Using ``easy_install``, which is a feature of `setuptools
-  <http://peak.telecommunity.com/DevCenter/setuptools>`_.  This is the
-  preferred method of installation.
+- Using ``pip``, which is now the
+  preferred method of installation for Python packages.
 
 - By downloading the Supervisor package and invoking
   a command.
 
-Internet-Installing With Setuptools
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Internet-Installing With Pip
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If the Python interpreter you're using has Setuptools installed, and
+If the Python interpreter you're using has ``pip`` installed, and
 the system has internet access, you can download and install
-supervisor in one step using ``easy_install``.
+supervisor in one step using ``pip``.
 
 .. code-block:: bash
 
-   easy_install supervisor
+   pip install supervisor
 
 Depending on the permissions of your system's Python, you might need
 to be the root user to install Supervisor successfully using
-``easy_install``.
+``pip``.
 
-Internet-Installing Without Setuptools
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+You can also install supervisor in a virtualenv via ``pip``.
 
-If your system does not have setuptools installed, you will need to download
+Internet-Installing Without Pip
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If your system does not have ``pip`` installed, you will need to download
 the Supervisor distribution and install it by hand.  Current and previous
 Supervisor releases may be downloaded from `PyPi
 <http://pypi.python.org/pypi/supervisor>`_.  After unpacking the software
@@ -54,7 +55,7 @@ Installing To A System Without Internet Access
 
 If the system that you want to install Supervisor to does not have
 Internet access, you'll need to perform installation slightly
-differently.  Since both ``easy_install`` and ``python setup.py
+differently.  Since both ``pip`` and ``python setup.py
 install`` depend on internet access to perform downloads of dependent
 software, neither will work on machines without internet access until
 dependencies are installed.  To install to a machine which is not

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -7,21 +7,10 @@ you're attempting to install Supervisor has internet access.
 Installing to A System With Internet Access
 -------------------------------------------
 
-If your system has internet access, you can get Supervisor
-installed in two ways:
-
-- Using ``pip``, which is now the
-  preferred method of installation for Python packages.
-
-- By downloading the Supervisor package and invoking
-  a command.
-
 Internet-Installing With Pip
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If the Python interpreter you're using has ``pip`` installed, and
-the system has internet access, you can download and install
-supervisor in one step using ``pip``.
+Supervisor can be installed with ``pip install``:
 
 .. code-block:: bash
 
@@ -113,15 +102,6 @@ the system boots.
     by the initial release of the package.  The package was fixed later.  See
     `Ubuntu Bug #1594740 <https://bugs.launchpad.net/ubuntu/+source/supervisor/+bug/1594740>`_
     for more information.
-
-Installing via pip
-------------------
-
-Supervisor can be installed with ``pip install``:
-
-.. code-block:: bash
-
-    pip install supervisor
 
 Creating a Configuration File
 -----------------------------


### PR DESCRIPTION
Today, `pip` has replaced `easy_install` to install python packages.

This PR updates documentation and fixes issue #623 