### PR TITLE
Update pypi.python.org URLs to pypi.org

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -26,8 +26,8 @@ Glossary
    Superlance
      A package which provides various event listener implementations
      that plug into Supervisor which can help monitor process memory
-     usage and crash status: `http://pypi.python.org/pypi/superlance
-     <http://pypi.python.org/pypi/superlance>`_.
+     usage and crash status: `https://pypi.org/pypi/superlance/
+     <https://pypi.org/pypi/superlance/>`_.
 
 
 

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -38,7 +38,7 @@ Internet-Installing Without Setuptools
 If your system does not have setuptools installed, you will need to download
 the Supervisor distribution and install it by hand.  Current and previous
 Supervisor releases may be downloaded from `PyPi
-<http://pypi.python.org/pypi/supervisor>`_.  After unpacking the software
+<https://pypi.org/pypi/supervisor/>`_.  After unpacking the software
 archive, run ``python setup.py install``.  This requires internet access.  It
 will download and install all distributions depended upon by Supervisor and
 finally install Supervisor itself.
@@ -61,11 +61,11 @@ dependencies are installed.  To install to a machine which is not
 internet-connected, obtain the following dependencies on a machine
 which is internet-connected:
 
-- setuptools (latest) from `https://pypi.python.org/pypi/setuptools
-  <https://pypi.python.org/pypi/setuptools>`_.
+- setuptools (latest) from `https://pypi.org/pypi/setuptools/
+  <https://pypi.org/pypi/setuptools/>`_.
 
-- meld3 (latest) from `https://pypi.python.org/pypi/meld3
-  <https://pypi.python.org/pypi/meld3>`_.
+- meld3 (latest) from `https://pypi.org/pypi/meld3/
+  <https://pypi.org/pypi/meld3/>`_.
 
 Copy these files to removable media and put them on the target
 machine.  Install each onto the target machine as per its

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -52,7 +52,7 @@ Third Party Plugins and Libraries for Supervisor
 These are plugins and libraries that add new functionality to Supervisor.
 These also includes various event listeners.
 
-`superlance <http://pypi.python.org/pypi/superlance>`_
+`superlance <https://pypi.org/pypi/superlance/>`_
     Provides set of common eventlisteners that can be used to monitor
     and, for example, restart when it uses too much memory etc.
 `mr.rubber <https://github.com/collective/mr.rubber>`_
@@ -113,9 +113,9 @@ Libraries that integrate Third Party Applications with Supervisor
 These are libraries and plugins that makes it easier to use Supervisor
 with third party applications:
 
-`django-supervisor <http://pypi.python.org/pypi/django-supervisor/>`_
+`django-supervisor <https://pypi.org/pypi/django-supervisor/>`_
     Easy integration between djangocl and supervisord.
-`collective.recipe.supervisor <http://pypi.python.org/pypi/collective.recipe.supervisor>`_
+`collective.recipe.supervisor <https://pypi.org/pypi/collective.recipe.supervisor/>`_
     A buildout recipe to install supervisor.
 `puppet-module-supervisor <https://github.com/plathrop/puppet-module-supervisor>`_
     Puppet module for configuring the supervisor daemon tool.


### PR DESCRIPTION
This PR updates the protocol, domain and add a trailing slash to the URLs.