### PR TITLE
Web UI: Renamed "Tail -f" to stdout and added "stderr" to get tail -f stderr

### DIFF
--- a/supervisor/web.py
+++ b/supervisor/web.py
@@ -260,18 +260,23 @@ class StatusView(MeldView):
         'href':'index.html?processname=%s&amp;action=clearlog' % processname,
         'target':None,
         }
-        tailf = {
-        'name':'Tail -f',
+        stdout = {
+        'name':'stdout',
         'href':'logtail/%s' % processname,
         'target':'_blank'
         }
+        stderr = {
+        'name':'stderr',
+        'href':'logtail/%s/stderr' % processname,
+        'target':'_blank'
+        }
         if state == ProcessStates.RUNNING:
-            actions = [restart, stop, clearlog, tailf]
+            actions = [restart, stop, clearlog, stdout, stderr]
         elif state in (ProcessStates.STOPPED, ProcessStates.EXITED,
                        ProcessStates.FATAL):
-            actions = [start, None, clearlog, tailf]
+            actions = [start, None, clearlog, stdout, stderr]
         else:
-            actions = [None, None, clearlog, tailf]
+            actions = [None, None, clearlog, stdout, stderr]
         return actions
 
     def css_class_for_state(self, state):


### PR DESCRIPTION
I have been using supervisor for years and it has been forever frustrating that there is only the "Tail -f" option when often stderr is the thing I really want to see, in my fork I have replaced "Tail -f" with "stdout" and added an equivalent "stderr" which calls "'logtail/%s/stderr' % processname". I would be forever grateful if you would consider making this change to supervisor.