### PR TITLE
xmlrpc: properly close connection on SupervisorTransport.close

### DIFF
--- a/supervisor/tests/test_xmlrpc.py
+++ b/supervisor/tests/test_xmlrpc.py
@@ -508,6 +508,17 @@ class SupervisorTransportTests(unittest.TestCase):
         self.assertEqual(dummy_conn.requestargs[3]['Accept'], 'text/xml')
         self.assertEqual(result, ('South Dakota',))
 
+    def test_close(self):
+        transport = self._makeOne('user', 'pass', 'http://127.0.0.1/')
+        dummy_conn = DummyConnection(200, '''<?xml version="1.0"?>
+        <methodResponse><params/></methodResponse>''')
+        def getconn():
+            return dummy_conn
+        transport._get_connection = getconn
+        transport.request('localhost', '/', '')
+        transport.close()
+        self.assertTrue(dummy_conn.closed)
+
 class TestDeferredXMLRPCResponse(unittest.TestCase):
     def _getTargetClass(self):
         from supervisor.xmlrpc import DeferredXMLRPCResponse

--- a/supervisor/xmlrpc.py
+++ b/supervisor/xmlrpc.py
@@ -507,6 +507,11 @@ class SupervisorTransport(xmlrpclib.Transport):
         else:
             raise ValueError('Unknown protocol for serverurl %s' % serverurl)
 
+    def close(self):
+      if self.connection:
+        self.connection.close()
+        self.connection = None
+
     def request(self, host, handler, request_body, verbose=0):
         request_body = as_bytes(request_body)
         if not self.connection:


### PR DESCRIPTION
Method on parent class ( xmlrpclib.Transport.close ) expect connection to be
self._connection[1], but SupervisorTransport use self.connection for the
socket. Implement SupervisorTransport.close which uses self.connection.

Fixes #1184