### PR TITLE
Freezing zombie channels into a list avoids RuntimeError

### DIFF
--- a/supervisor/medusa/http_server.py
+++ b/supervisor/medusa/http_server.py
@@ -506,7 +506,7 @@ class http_channel (asynchat.async_chat):
 
     def kill_zombies (self):
         now = int (time.time())
-        for channel in asyncore.socket_map.values():
+        for channel in list(asyncore.socket_map.values()):
             if channel.__class__ == self.__class__:
                 if (now - channel.last_used) > channel.zombie_timeout:
                     channel.close()


### PR DESCRIPTION
Fixes #1178 which says that a ___RuntimeError___ is raised when the dictionary size changes during iteration.  This change freezes dict.values() into a list before the loop begins so that the list will not change during iteration. 🎄 