### PR TITLE
Add option to customize log format

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -400,6 +400,7 @@ class ServerOptions(Options):
     sockchmod = None
     logfile = None
     loglevel = None
+    logformat = None
     pidfile = None
     passwdfile = None
     nodaemon = None
@@ -431,6 +432,8 @@ class ServerOptions(Options):
                  "z:", "logfile_backups=", integer, default=10)
         self.add("loglevel", "supervisord.loglevel", "e:", "loglevel=",
                  logging_level, default="info")
+        self.add("logformat", "supervisord.logformat", "", "logformat=",
+                 str, default='%(asctime)s %(levelname)s %(message)s')
         self.add("pidfile", "supervisord.pidfile", "j:", "pidfile=",
                  existing_dirpath, default="supervisord.pid")
         self.add("identifier", "supervisord.identifier", "i:", "identifier=",
@@ -492,6 +495,9 @@ class ServerOptions(Options):
 
         if not self.loglevel:
             self.loglevel = section.loglevel
+
+        if not self.logformat:
+            self.logformat = section.logformat
 
         if self.logfile:
             logfile = self.logfile
@@ -635,6 +641,7 @@ class ServerOptions(Options):
         section.logfile_maxbytes = byte_size(get('logfile_maxbytes', '50MB'))
         section.logfile_backups = integer(get('logfile_backups', 10))
         section.loglevel = logging_level(get('loglevel', 'info'))
+        section.logformat = str(get('logformat', '%(asctime)s %(levelname)s %(message)s', do_expand=False))
         section.pidfile = existing_dirpath(get('pidfile', 'supervisord.pid'))
         section.identifier = get('identifier', 'supervisor')
         section.nodaemon = boolean(get('nodaemon', 'false'))
@@ -1447,7 +1454,7 @@ class ServerOptions(Options):
 
     def make_logger(self):
         # must be called after realize() and after supervisor does setuid()
-        format = '%(asctime)s %(levelname)s %(message)s\n'
+        format = self.logformat+'\n'
         self.logger = loggers.getLogger(self.loglevel)
         if self.nodaemon:
             loggers.handle_stdout(self.logger, format)

--- a/supervisor/tests/test_options.py
+++ b/supervisor/tests/test_options.py
@@ -444,6 +444,7 @@ class ServerOptionsTests(unittest.TestCase):
         logfile_maxbytes=1000MB
         logfile_backups=5
         loglevel=error
+        logformat=%%(asctime)s | %%(levelname)s | %%(message)s
         pidfile=supervisord.pid
         nodaemon=true
         identifier=fleeb
@@ -513,6 +514,7 @@ class ServerOptionsTests(unittest.TestCase):
         self.assertEqual(options.logfile_maxbytes, 1000 * 1024 * 1024)
         self.assertEqual(options.logfile_backups, 5)
         self.assertEqual(options.loglevel, 40)
+        self.assertEqual(options.logformat, '%(asctime)s | %(levelname)s | %(message)s')
         self.assertEqual(options.pidfile, 'supervisord.pid')
         self.assertEqual(options.nodaemon, True)
         self.assertEqual(options.identifier, 'fleeb')
@@ -662,6 +664,7 @@ class ServerOptionsTests(unittest.TestCase):
         self.assertEqual(instance.logfile_maxbytes, 1000 * 1024 * 1024)
         self.assertEqual(instance.logfile_backups, 5)
         self.assertEqual(instance.loglevel, 40)
+        self.assertEqual(instance.logformat, '%(asctime)s | %(levelname)s | %(message)s')
         self.assertEqual(instance.pidfile, os.path.join(here,'supervisord.pid'))
         self.assertEqual(instance.nodaemon, True)
         self.assertEqual(instance.passwdfile, None)


### PR DESCRIPTION
Allows customizing the default ```%(asctime)s %(levelname)s %(message)s``` format to something different. Can be useful for getting JSON format logs, for example.