### PR TITLE
Add a new CLI option called "--strict_config_parsing_off"

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -447,6 +447,7 @@ class ServerOptions(Options):
                  "t", "strip_ansi", flag=1, default=0)
         self.add("profile_options", "supervisord.profile_options",
                  "", "profile_options=", profile_options, default=None)
+        self.add(None, None, "", "strict_config_parsing_off")
         self.pidhistory = {}
         self.process_group_configs = []
         self.parse_criticals = []
@@ -561,7 +562,8 @@ class ServerOptions(Options):
             except (IOError, OSError):
                 raise ValueError("could not read config file %s" % fp)
 
-        parser = UnhosedConfigParser()
+        is_strict_config_parsing_enabled = '--strict_config_parsing_off' not in dict(self.options)
+        parser = UnhosedConfigParser(strict=is_strict_config_parsing_enabled)
         parser.expansions = self.environ_expansions
         try:
             try:


### PR DESCRIPTION
This change adds backward compatibility for config file originally designed to work without strict parsing. For Py2, the config parser has strict parsing turned OFF by default. Strict parsing is turned ON by default for Py3.

**Edit**
Description of `strict` option from the Python docs:
"When set to True, the parser will not allow for any section or option duplicates while reading from a single source (using read_file(), read_string() or read_dict())."

Practically speaking, if you are upgrading from Py2 to Py3 you may have supervisor config files that have duplicate options (e.g. "environment=" multiple times for multiple environment variables). This change allows existing config files to be used to ease the transition to supervisor on Py3.