### PR TITLE
Fix Pytest DeprecationWarning: invalid escape sequence \s

### DIFF
--- a/supervisor/tests/test_end_to_end.py
+++ b/supervisor/tests/test_end_to_end.py
@@ -71,7 +71,7 @@ class EndToEndTests(BaseTestCase):
         supervisorctl = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisorctl.kill, signal.SIGINT)
         try:
-            supervisorctl.expect('test_öäü\s+RUNNING', timeout=30)
+            supervisorctl.expect('test_öäü\\s+RUNNING', timeout=30)
             seen = True
         except pexpect.ExceptionPexpect:
             seen = False
@@ -123,7 +123,7 @@ class EndToEndTests(BaseTestCase):
         args = ['-m', 'supervisor.supervisorctl', '-c', filename, 'avail']
         supervisorctl = pexpect.spawn(sys.executable, args, encoding='utf-8')
         try:
-            supervisorctl.expect('cat\s+in use\s+auto', timeout=30)
+            supervisorctl.expect('cat\s+in use\\s+auto', timeout=30)
             seen = True
         except pexpect.ExceptionPexpect:
             seen = False


### PR DESCRIPTION
https://travis-ci.org/Supervisor/supervisor/jobs/516836395#L260-L269
```
=============================== warnings summary ===============================
supervisor/tests/test_end_to_end.py:74
  /home/travis/build/Supervisor/supervisor/supervisor/tests/test_end_to_end.py:74: DeprecationWarning: invalid escape sequence \s
    supervisorctl.expect('test_öäü\s+RUNNING', timeout=30)
supervisor/tests/test_end_to_end.py:126
  /home/travis/build/Supervisor/supervisor/supervisor/tests/test_end_to_end.py:126: DeprecationWarning: invalid escape sequence \s
    supervisorctl.expect('cat\s+in use\s+auto', timeout=30)
-- Docs: https://docs.pytest.org/en/latest/warnings.html
```