### PR TITLE
Ensure main log rotation can be disabled the same way as child logs

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -1467,7 +1467,7 @@ class ServerOptions(Options):
             self.logger,
             self.logfile,
             format,
-            rotating=True,
+            rotating=not not self.logfile_maxbytes,
             maxbytes=self.logfile_maxbytes,
             backups=self.logfile_backups,
         )


### PR DESCRIPTION
Fixes #1224 