### PR TITLE
Initial cut for fix of issue #1231

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 *~
-*.conf
 *.egg
 *.egg-info
 *.log

--- a/supervisor/supervisorctl.py
+++ b/supervisor/supervisorctl.py
@@ -440,6 +440,14 @@ class DefaultControllerPlugin(ControllerPluginBase):
     name = 'default'
     listener = None # for unit tests
     def _tailf(self, path):
+        def not_all_langs():
+            enc = getattr(sys.stdout, 'encoding', '').lower()
+            return None if enc.startswith('utf') else sys.stdout.encoding
+
+        problematic_enc = not_all_langs()
+        if problematic_enc:
+            self.ctl.output('Warning: sys.stdout.encoding is set to %s, so '
+                            'Unicode output may fail.' % problematic_enc)
         self.ctl.output('==> Press Ctrl-C to exit <==')
 
         username = self.ctl.options.username

--- a/supervisor/tests/fixtures/issue-1231.conf
+++ b/supervisor/tests/fixtures/issue-1231.conf
@@ -1,0 +1,17 @@
+[supervisord]
+loglevel=info                ; log level; default info; others: debug,warn,trace
+logfile=/tmp/issue-1231.log  ; main log file; default $CWD/supervisord.log
+pidfile=/tmp/issue-1231.pid  ; supervisord pidfile; default supervisord.pid
+nodaemon=true                ; start in foreground if true; default false
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[unix_http_server]
+file=/tmp/issue-1231.sock    ; the path to the socket file
+
+[supervisorctl]
+serverurl=unix:///tmp/issue-1231.sock   ; use a unix:// URL  for a unix socket
+
+[program:hello]
+command=python %(here)s/test_1231.py

--- a/supervisor/tests/fixtures/test_1231.py
+++ b/supervisor/tests/fixtures/test_1231.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+import logging
+import random
+import sys
+import time
+
+def main():
+    logging.basicConfig(level=logging.INFO, stream=sys.stdout,
+                        format='%(levelname)s [%(asctime)s] %(message)s',
+                        datefmt='%m-%d|%H:%M:%S')
+    i = 1
+    while True:
+        delay = random.randint(400, 1200)
+        time.sleep(delay / 1000.0)
+        logging.info('%d - hash=57d94b…381088', i)
+        i += 1
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
I've added a warning in the `tailf` command, and also changed the exception raised on `UnicodeEncodeError` to have a more informative message. A couple of related new end-to-end tests have been added and on my Ubuntu system, all tests pass with `tox` on all configured platforms.