### PR TITLE
Added "STDOUT" value for "stdout_logfile" option

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -869,9 +869,11 @@ where specified.
   true, also place stderr output in this file).  If ``stdout_logfile``
   is unset or set to ``AUTO``, supervisor will automatically choose a
   file location.  If this is set to ``NONE``, supervisord will create
-  no log file.  ``AUTO`` log files and their backups will be deleted
-  when :program:`supervisord` restarts.  The ``stdout_logfile`` value
-  can contain Python string expressions that will evaluated against a
+  no log file. If this is set to ``STDOUT``, supervisord will handle
+  stdout as ``stream`` not a ``file`` (useful when using systemd logging)
+  ``AUTO`` log files and their backups will be deleted when
+  :program:`supervisord` restarts.  The ``stdout_logfile`` value can
+  contain Python string expressions that will evaluated against a
   dictionary that contains the keys ``group_name``, ``host_node_name``,
   ``process_num``, ``program_name``, and ``here`` (the directory of the
   supervisord config file).
@@ -885,8 +887,8 @@ where specified.
   .. note::
 
     If ``stdout_logfile`` is set to a special file like ``/dev/stdout``
-    that is not seekable, log rotation must be disabled by setting
-    ``stdout_logfile_maxbytes = 0``.
+    or a stream like ``STDOUT`` that is not seekable, log rotation must
+    be disabled by setting ``stdout_logfile_maxbytes = 0``.
 
   *Default*: ``AUTO``
 

--- a/supervisor/loggers.py
+++ b/supervisor/loggers.py
@@ -105,6 +105,8 @@ class Handler:
                 # which deliberately raises an exception the first
                 # time it's called. So just do it again
                 self.stream.write(msg)
+            except TypeError:
+                self.stream.write(msg.decode(sys.stdout.encoding))
             self.flush()
         except:
             self.handleError()


### PR DESCRIPTION
There is issue with using `supervisor` with `systemd`.
The `systemd` redirects stdout/stderr for runned processes using sockets.
But `supervisor` for logging child's stdout/stderr uses an system call `open` that does not know how to work with sockets ([similar situation described here](https://bugzilla.redhat.com/show_bug.cgi?id=1212756#c4)), so when you specify 
```
stdout_logfile=/dev/stdout
```
in configuration you will get error like  
```
INFO spawnerr: unknown error making dispatchers for 'app1': ENXIO
```
This PR adds the ability to redirect the output of the program through `StreamHandler` instead `FileHandler`, allowing you forward logs directly to `journald`.

PS: Sorry for my English. I'm not a fluent speaker