### PR TITLE
Fix tail bug

### DIFF
--- a/supervisor/supervisorctl.py
+++ b/supervisor/supervisorctl.py
@@ -538,7 +538,7 @@ class DefaultControllerPlugin(ControllerPluginBase):
         else:
             check_encoding(self.ctl)
             try:
-                if channel is 'stdout':
+                if channel == 'stdout':
                     output = supervisor.readProcessStdoutLog(name,
                                                              -bytes, 0)
                 else: # if channel is 'stderr'


### PR DESCRIPTION
The bug was that when the channel was explicitly specified, it always
evaluated to stderr, i.e. supervisorctl tail foo stdout and
supervisorctl tail foo stderr were both showing stderr.
That is because we should not use is for such comparisons:
these two are different objects.

If curious, read more here: https://stackoverflow.com/questions/1504717/

This just changes the tail command to use == for comparing the two objects.