### PR TITLE
Use html.escape for python >= 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,11 @@ matrix:
             - TOXENV=py37
             - END_TO_END=1
           dist: xenial          # required for Python >= 3.7
+        - python: 3.8-dev
+          env:
+            - TOXENV=py38
+            - END_TO_END=1
+          dist: xenial          # required for Python >= 3.7
         - name: "Python: 3.7 on macOS"
           language: sh          # 'language: python' is not yet supported on Travis CI macOS
           os: osx

--- a/supervisor/medusa/util.py
+++ b/supervisor/medusa/util.py
@@ -1,4 +1,10 @@
-from cgi import escape
+from supervisor.compat import PY2
+
+if PY2:
+    from cgi import escape
+else:
+    from html import escape
+
 
 def html_repr (object):
     so = escape (repr (object))

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    cover,cover3,docs,py27,py34,py35,py36,py37
+    cover,cover3,docs,py27,py34,py35,py36,py37,py38
 
 [testenv]
 deps =


### PR DESCRIPTION
fix #1257 

the html module is missing in python 2 and I don't think is worth using cgi only for 3.8+ so I opted for cgi on python 2 and html for python 3+