### PR TITLE
Tell reverse proxy server to disable proxy buffering

### DIFF
--- a/supervisor/http.py
+++ b/supervisor/http.py
@@ -748,6 +748,9 @@ class logtail_handler:
         request['Content-Type'] = 'text/plain;charset=utf-8'
         # the lack of a Content-Length header makes the outputter
         # send a 'Transfer-Encoding: chunked' response
+        request['X-Accel-Buffering'] = 'no'
+        # tell reverse proxy server (e.g., nginx) to disable proxy buffering
+        # (see also http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering)
 
         request.push(tail_f_producer(request, logfile, 1024))
 

--- a/supervisor/tests/test_http.py
+++ b/supervisor/tests/test_http.py
@@ -70,6 +70,7 @@ class LogtailHandlerTests(HandlerTests, unittest.TestCase):
             self.assertEqual(request.headers['Last-Modified'],
                 http_date.build_http_date(os.stat(t)[stat.ST_MTIME]))
             self.assertEqual(request.headers['Content-Type'], 'text/plain;charset=utf-8')
+            self.assertEqual(request.headers['X-Accel-Buffering'], 'no')
             self.assertEqual(len(request.producers), 1)
             self.assertEqual(request._done, True)
 


### PR DESCRIPTION
When supervisord behind nginx, `/logtail/PROGRAM` does not produce
log text because nginx proxy buffering is enabled by default:

http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering

And I don't want tell everyone howto configure `proxy_buffering off;`,
so better let supervisord set http header X-Accel-Buffering to `no`.