### PR TITLE
Flag to disable stdout logging for non daemonized instances

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -334,6 +334,16 @@ follows.
 
   *Introduced*: 3.0
 
+``silent``
+
+  If true and not daemonized, logs will not be directed to stdout.
+
+  *Default*:  false
+
+  *Required*: No.
+
+  *Introduced*: 4.2.0
+
 ``minfds``
 
   The minimum number of file descriptors that must be available before

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -79,6 +79,10 @@ value in the configuration file.
 
    Run :program:`supervisord` in the foreground.
 
+-s, --silent
+
+   No output directed to stdout.
+
 -h, --help
 
    Show :command:`supervisord` command help.

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -403,7 +403,7 @@ class ServerOptions(Options):
     pidfile = None
     passwdfile = None
     nodaemon = None
-    quiet = None
+    silent = None
     environment = None
     httpservers = ()
     unlink_pidfile = False
@@ -448,8 +448,8 @@ class ServerOptions(Options):
                  "t", "strip_ansi", flag=1, default=0)
         self.add("profile_options", "supervisord.profile_options",
                  "", "profile_options=", profile_options, default=None)
-        self.add("quiet", "supervisord.quiet",
-                 "s", "quiet", flag=1, default=0)
+        self.add("silent", "supervisord.silent",
+                 "s", "silent", flag=1, default=0)
         self.pidhistory = {}
         self.process_group_configs = []
         self.parse_criticals = []
@@ -641,7 +641,7 @@ class ServerOptions(Options):
         section.pidfile = existing_dirpath(get('pidfile', 'supervisord.pid'))
         section.identifier = get('identifier', 'supervisor')
         section.nodaemon = boolean(get('nodaemon', 'false'))
-        section.quiet = boolean(get('quiet', 'false'))
+        section.silent = boolean(get('silent', 'false'))
 
         tempdir = tempfile.gettempdir()
         section.childlogdir = existing_directory(get('childlogdir', tempdir))
@@ -1465,7 +1465,7 @@ class ServerOptions(Options):
         # must be called after realize() and after supervisor does setuid()
         format = '%(asctime)s %(levelname)s %(message)s\n'
         self.logger = loggers.getLogger(self.loglevel)
-        if self.nodaemon and not self.quiet:
+        if self.nodaemon and not self.silent:
             loggers.handle_stdout(self.logger, format)
         loggers.handle_file(
             self.logger,

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -447,6 +447,8 @@ class ServerOptions(Options):
                  "t", "strip_ansi", flag=1, default=0)
         self.add("profile_options", "supervisord.profile_options",
                  "", "profile_options=", profile_options, default=None)
+        self.add("quiet", "supervisord.quiet",
+                 "q", "quiet", flag=1, default=0)
         self.pidhistory = {}
         self.process_group_configs = []
         self.parse_criticals = []

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -1465,7 +1465,7 @@ class ServerOptions(Options):
         # must be called after realize() and after supervisor does setuid()
         format = '%(asctime)s %(levelname)s %(message)s\n'
         self.logger = loggers.getLogger(self.loglevel)
-        if self.nodaemon and not quiet:
+        if self.nodaemon and not self.quiet:
             loggers.handle_stdout(self.logger, format)
         loggers.handle_file(
             self.logger,

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -449,7 +449,7 @@ class ServerOptions(Options):
         self.add("profile_options", "supervisord.profile_options",
                  "", "profile_options=", profile_options, default=None)
         self.add("quiet", "supervisord.quiet",
-                 "q", "quiet", flag=1, default=0)
+                 "s", "quiet", flag=1, default=0)
         self.pidhistory = {}
         self.process_group_configs = []
         self.parse_criticals = []

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -403,6 +403,7 @@ class ServerOptions(Options):
     pidfile = None
     passwdfile = None
     nodaemon = None
+    quiet = None
     environment = None
     httpservers = ()
     unlink_pidfile = False
@@ -640,6 +641,7 @@ class ServerOptions(Options):
         section.pidfile = existing_dirpath(get('pidfile', 'supervisord.pid'))
         section.identifier = get('identifier', 'supervisor')
         section.nodaemon = boolean(get('nodaemon', 'false'))
+        section.quiet = boolean(get('quiet', 'false'))
 
         tempdir = tempfile.gettempdir()
         section.childlogdir = existing_directory(get('childlogdir', tempdir))
@@ -1463,7 +1465,7 @@ class ServerOptions(Options):
         # must be called after realize() and after supervisor does setuid()
         format = '%(asctime)s %(levelname)s %(message)s\n'
         self.logger = loggers.getLogger(self.loglevel)
-        if self.nodaemon:
+        if self.nodaemon and not quiet:
             loggers.handle_stdout(self.logger, format)
         loggers.handle_file(
             self.logger,

--- a/supervisor/skel/sample.conf
+++ b/supervisor/skel/sample.conf
@@ -48,6 +48,7 @@ logfile_backups=10           ; # of main logfile backups; 0 means none, default 
 loglevel=info                ; log level; default info; others: debug,warn,trace
 pidfile=/tmp/supervisord.pid ; supervisord pidfile; default supervisord.pid
 nodaemon=false               ; start in foreground if true; default false
+silent=false                 ; no logs to stdout if true; default false
 minfds=1024                  ; min. avail startup file descriptors; default 1024
 minprocs=200                 ; min. avail process descriptors;default 200
 ;umask=022                   ; process file creation umask; default 022

--- a/supervisor/supervisord.py
+++ b/supervisor/supervisord.py
@@ -7,6 +7,7 @@ Usage: %s [options]
 Options:
 -c/--configuration FILENAME -- configuration file path (searches if not given)
 -n/--nodaemon -- run in the foreground (same as 'nodaemon=true' in config file)
+-s/--silent -- no logs to stdout (maps to 'silent=true' in config file)
 -h/--help -- print this usage message and exit
 -v/--version -- print supervisord version number and exit
 -u/--user USER -- run supervisord as this user (or numeric uid)

--- a/supervisor/tests/base.py
+++ b/supervisor/tests/base.py
@@ -89,6 +89,7 @@ class DummyOptions:
         self.chdir_error = None
         self.umaskset = None
         self.poller = DummyPoller(self)
+        self.silent = False
 
     def getLogger(self, *args, **kw):
         logger = DummyLogger()

--- a/supervisor/tests/test_options.py
+++ b/supervisor/tests/test_options.py
@@ -470,6 +470,7 @@ class ServerOptionsTests(unittest.TestCase):
         loglevel=error
         pidfile=supervisord.pid
         nodaemon=true
+        quiet=true
         identifier=fleeb
         childlogdir=%(tempdir)s
         nocleanup=true
@@ -539,6 +540,7 @@ class ServerOptionsTests(unittest.TestCase):
         self.assertEqual(options.loglevel, 40)
         self.assertEqual(options.pidfile, 'supervisord.pid')
         self.assertEqual(options.nodaemon, True)
+        self.assertEqual(options.quiet, True)
         self.assertEqual(options.identifier, 'fleeb')
         self.assertEqual(options.childlogdir, tempfile.gettempdir())
         self.assertEqual(len(options.server_configs), 1)
@@ -688,6 +690,7 @@ class ServerOptionsTests(unittest.TestCase):
         self.assertEqual(instance.loglevel, 40)
         self.assertEqual(instance.pidfile, os.path.join(here,'supervisord.pid'))
         self.assertEqual(instance.nodaemon, True)
+        self.assertEqual(instance.quiet, True)
         self.assertEqual(instance.passwdfile, None)
         self.assertEqual(instance.identifier, 'fleeb')
         self.assertEqual(instance.childlogdir, tempfile.gettempdir())

--- a/supervisor/tests/test_options.py
+++ b/supervisor/tests/test_options.py
@@ -470,7 +470,7 @@ class ServerOptionsTests(unittest.TestCase):
         loglevel=error
         pidfile=supervisord.pid
         nodaemon=true
-        quiet=true
+        silent=true
         identifier=fleeb
         childlogdir=%(tempdir)s
         nocleanup=true
@@ -540,7 +540,7 @@ class ServerOptionsTests(unittest.TestCase):
         self.assertEqual(options.loglevel, 40)
         self.assertEqual(options.pidfile, 'supervisord.pid')
         self.assertEqual(options.nodaemon, True)
-        self.assertEqual(options.quiet, True)
+        self.assertEqual(options.silent, True)
         self.assertEqual(options.identifier, 'fleeb')
         self.assertEqual(options.childlogdir, tempfile.gettempdir())
         self.assertEqual(len(options.server_configs), 1)
@@ -690,7 +690,7 @@ class ServerOptionsTests(unittest.TestCase):
         self.assertEqual(instance.loglevel, 40)
         self.assertEqual(instance.pidfile, os.path.join(here,'supervisord.pid'))
         self.assertEqual(instance.nodaemon, True)
-        self.assertEqual(instance.quiet, True)
+        self.assertEqual(instance.silent, True)
         self.assertEqual(instance.passwdfile, None)
         self.assertEqual(instance.identifier, 'fleeb')
         self.assertEqual(instance.childlogdir, tempfile.gettempdir())
@@ -1820,6 +1820,7 @@ class ServerOptionsTests(unittest.TestCase):
             'ENV_SUPD_LOGFILE_BACKUPS': '10',
             'ENV_SUPD_LOGLEVEL': 'info',
             'ENV_SUPD_NODAEMON': 'false',
+            'ENV_SUPD_SILENT': 'false',
             'ENV_SUPD_MINFDS': '1024',
             'ENV_SUPD_MINPROCS': '200',
             'ENV_SUPD_UMASK': '002',
@@ -1855,6 +1856,7 @@ class ServerOptionsTests(unittest.TestCase):
         self.assertEqual(instance.logfile_backups, 10)
         self.assertEqual(instance.loglevel, LevelsByName.INFO)
         self.assertEqual(instance.nodaemon, False)
+        self.assertEqual(instance.silent, False)
         self.assertEqual(instance.minfds, 1024)
         self.assertEqual(instance.minprocs, 200)
         self.assertEqual(instance.nocleanup, True)

--- a/supervisor/tests/test_supervisord.py
+++ b/supervisor/tests/test_supervisord.py
@@ -69,6 +69,48 @@ class EntryPointTests(unittest.TestCase):
             output = new_stdout.getvalue()
             self.assertTrue('cumulative time, call count' in output, output)
 
+    def test_silent_off(self):
+        from supervisor.supervisord import main
+        conf = os.path.join(
+            os.path.abspath(os.path.dirname(__file__)), 'fixtures',
+            'donothing.conf')
+        new_stdout = StringIO()
+        new_stdout.fileno = lambda: 1
+        old_stdout = sys.stdout
+
+        try:
+            tempdir = tempfile.mkdtemp()
+            log = os.path.join(tempdir, 'log')
+            pid = os.path.join(tempdir, 'pid')
+            sys.stdout = new_stdout
+            main(args=['-c', conf, '-l', log, '-j', pid, '-n'], test=True)
+        finally:
+            sys.stdout = old_stdout
+            shutil.rmtree(tempdir)
+        output = new_stdout.getvalue()
+        self.assertGreater(len(output), 0)
+
+    def test_silent_on(self):
+        from supervisor.supervisord import main
+        conf = os.path.join(
+            os.path.abspath(os.path.dirname(__file__)), 'fixtures',
+            'donothing.conf')
+        new_stdout = StringIO()
+        new_stdout.fileno = lambda: 1
+        old_stdout = sys.stdout
+
+        try:
+            tempdir = tempfile.mkdtemp()
+            log = os.path.join(tempdir, 'log')
+            pid = os.path.join(tempdir, 'pid')
+            sys.stdout = new_stdout
+            main(args=['-c', conf, '-l', log, '-j', pid, '-n', '-s'], test=True)
+        finally:
+            sys.stdout = old_stdout
+            shutil.rmtree(tempdir)
+        output = new_stdout.getvalue()
+        self.assertEqual(len(output), 0)
+
 class SupervisordTests(unittest.TestCase):
     def tearDown(self):
         from supervisor.events import clear


### PR DESCRIPTION
Added a new flag to disable logging to stdout for non daemonized instances. This is of use in a dockerized env where filebeat is being used to pump log files (including supervisord) to stdout in a standard format. Without this flag there are duplicated log entries written to stdout.

Closes #661 