### PR TITLE
fix #85 Supervisorctl tail fails on logs with ANSI codes

### DIFF
--- a/supervisor/rpcinterface.py
+++ b/supervisor/rpcinterface.py
@@ -703,8 +703,14 @@ class SupervisorNamespaceRPCInterface:
         if logfile is None or not os.path.exists(logfile):
             raise RPCError(Faults.NO_FILE, logfile)
 
+        # TODO: also provide a way to simply return logfile
+        # print(('D20191213T020824', logfile))
         try:
-            return as_string(readFile(logfile, int(offset), int(length)))
+            ret = as_string(readFile(logfile, int(offset), int(length)))
+            import base64
+            ret = base64.b64encode(ret.encode())
+            ret = ret.decode()
+            return ret
         except ValueError as inst:
             why = inst.args[0]
             raise RPCError(getattr(Faults, why))

--- a/supervisor/rpcinterface.py
+++ b/supervisor/rpcinterface.py
@@ -703,8 +703,6 @@ class SupervisorNamespaceRPCInterface:
         if logfile is None or not os.path.exists(logfile):
             raise RPCError(Faults.NO_FILE, logfile)
 
-        # TODO: also provide a way to simply return logfile
-        # print(('D20191213T020824', logfile))
         try:
             ret = as_string(readFile(logfile, int(offset), int(length)))
             import base64

--- a/supervisor/supervisorctl.py
+++ b/supervisor/supervisorctl.py
@@ -558,6 +558,9 @@ class DefaultControllerPlugin(ControllerPluginBase):
                 else:
                     raise
             else:
+                import base64
+                output = base64.b64decode(output)
+                output = output.decode("utf-8", "ignore")
                 self.ctl.output(output)
 
     def help_tail(self):


### PR DESCRIPTION
/cc @@mnaberez 
* fixes https://github.com/Supervisor/supervisor/issues/1293
* fixes https://github.com/Supervisor/supervisor/issues/85

this makes tail work robustly even in presence of binary non ascii data eg ansi color escape codes

EDIT

https://github.com/Supervisor/supervisor/pull/1307 actually also fixes https://github.com/Supervisor/supervisor/issues/1293 https://github.com/Supervisor/supervisor/issues/85
 via a more general solution that better interoperates with command line tools, so maybe this PR isn't essential after https://github.com/Supervisor/supervisor/pull/1307 gets merged