### PR TITLE
json query for process state: supervisorctl query <name>? <field>?

### DIFF
--- a/supervisor/supervisorctl.py
+++ b/supervisor/supervisorctl.py
@@ -477,6 +477,21 @@ class DefaultControllerPlugin(ControllerPluginBase):
             self.ctl.output('')
             return
 
+    def do_query(self, arg):
+      args = arg.split()
+      supervisor = self.ctl.get_supervisor()
+      import json
+      info = None
+      if len(args) > 0:
+        name = args[0]
+        info = supervisor.getProcessInfo(name)
+        if len(args) >= 2:
+          attr = args[1]
+          info = info[attr]
+      else:
+        info = supervisor.getAllProcessInfo()
+      self.ctl.output(json.dumps(info))
+
     def do_tail(self, arg):
         if not self.ctl.upcheck():
             return


### PR DESCRIPTION
/cc @@mnaberez

tiny patch that adds a new very useful command: query process status as json, either for a single or all child processes; and either for all fields or a given field. This provides a single command that is machine/user friendly and can be integrated in scripts easily as shown below

here are a few examples:

## query all (as json)
`supervisorctl query`
```
[{"name": "exposed_server", "group": "exposed_server", "start": 1576 ...
```

pipe to `jq`: (brew install jq)

`supervisorctl query | jq`
```json
[
 {
    "name": "grafana",
    "group": "grafana",
    "start": 1576242446,
    "stop": 1576242447,
    "now": 1576242884,
    "state": 200,
    "statename": "FATAL",
    "spawnerr": "Exited too quickly (process log may have details)",
    "exitstatus": 0,
    "logfile": "/Users/timothee/temp/supervisor/childlogs/grafana-stdout---supervisor-np6ee2_w.log",
    "stdout_logfile": "/Users/timothee/temp/supervisor/childlogs/grafana-stdout---supervisor-np6ee2_w.log",
    "stderr_logfile": "/Users/timothee/temp/supervisor/childlogs/grafana-stderr---supervisor-caj27bog.log",
    "pid": 0,
    "description": "Exited too quickly (process log may have details)"
  },
...
{
    "name": "livereload",
    "group": "livereload",
    "start": 1576242440,
    "stop": 1576242440,
    "now": 1576242884,
    "state": 200,
    "statename": "FATAL",
    "spawnerr": "Exited too quickly (process log may have details)",
    "exitstatus": 0,
    "logfile": "/Users/timothee/temp/supervisor/childlogs/livereload-stdout---supervisor-rfiufej2.log",
    "stdout_logfile": "/Users/timothee/temp/supervisor/childlogs/livereload-stdout---supervisor-rfiufej2.log",
    "stderr_logfile": "/Users/timothee/temp/supervisor/childlogs/livereload-stderr---supervisor-om24co1w.log",
    "pid": 0,
    "description": "Exited too quickly (process log may have details)"
  },
]
```


## for a single process:
`supervisorctl query temp2_cmd_echo_forever_color | jq`
```
{
  "name": "temp2_cmd_echo_forever_color",
  "group": "temp2_cmd_echo_forever_color",
  "start": 1576242437,
  "stop": 0,
  "now": 1576243121,
  "state": 20,
  "statename": "RUNNING",
  "spawnerr": "",
  "exitstatus": 0,
  "logfile": "/Users/timothee/temp/supervisor/childlogs/temp2_cmd_echo_forever_color-stdout---supervisor-8grxan5f.log",
  "stdout_logfile": "/Users/timothee/temp/supervisor/childlogs/temp2_cmd_echo_forever_color-stdout---supervisor-8grxan5f.log",
  "stderr_logfile": "/Users/timothee/temp/supervisor/childlogs/temp2_cmd_echo_forever_color-stderr---supervisor-9yk250km.log",
  "pid": 61809,
  "description": "pid 61809, uptime 0:11:24"
}
```

## for a single field:
`supervisorctl query myprog pid`
```
61809
```

this actually subsumes the pid command  `supervisorctl pid myprog`


## new use cases
the following is not possible prior to this PR: getting the stdout_logfile (etc):
`supervisorctl query temp2_cmd_echo_forever_color stdout_logfile`

example: (more flexible than tail -f, tail -100 etc):
`grep stdout $(supervisorctl query temp2_cmd_echo_forever_color stdout_logfile)`

this subsumes command supervisor tail -f:
```
tail -f $(supervisorctl query temp2_cmd_echo_forever_color stderr_logfile)
```
and better interoperates with command line tools

## note
actually this PR also provides a good workaround for https://github.com/Supervisor/supervisor/issues/1293 : 
```
tail -f $(supervisorctl query progname stderr_logfile)
```
