### PR TITLE
Fix order of search path for supervisord.conf in documentation

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -10,6 +10,10 @@ will look for a file named :file:`supervisord.conf` within the
 following locations, in the specified order.  It will use the first
 file it finds.
 
+#. :file:`../etc/supervisord.conf` (Relative to the executable)
+
+#. :file:`../supervisord.conf` (Relative to the executable)
+
 #. :file:`$CWD/supervisord.conf`
 
 #. :file:`$CWD/etc/supervisord.conf`
@@ -17,10 +21,6 @@ file it finds.
 #. :file:`/etc/supervisord.conf`
 
 #. :file:`/etc/supervisor/supervisord.conf` (since Supervisor 3.3.0)
-
-#. :file:`../etc/supervisord.conf` (Relative to the executable)
-
-#. :file:`../supervisord.conf` (Relative to the executable)
 
 .. note::
 


### PR DESCRIPTION
The code in `options.py` is as follow:
```        here = os.path.dirname(os.path.dirname(sys.argv[0]))
        searchpaths = [os.path.join(here, 'etc', 'supervisord.conf'),
                       os.path.join(here, 'supervisord.conf'),
                       'supervisord.conf',
                       'etc/supervisord.conf',
                       '/etc/supervisord.conf',
                       '/etc/supervisor/supervisord.conf',
                       ]
```