### PR TITLE
Reflect new glibc 2.31 default value for SOMAXCONN on tests (closes: #1346)

### DIFF
--- a/supervisor/tests/base.py
+++ b/supervisor/tests/base.py
@@ -358,7 +358,7 @@ class DummySocketConfig:
         return not self.__eq__(other)
 
     def get_backlog(self):
-        return 128
+        return 4096
 
     def create_and_bind(self):
         return DummySocket(self.fd)


### PR DESCRIPTION
closes: #1346