### PR TITLE
Add option to exit supervisord on exit (or bad restart) of the config…

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -910,6 +910,7 @@ class ServerOptions(Options):
         stopasgroup = boolean(get(section, 'stopasgroup', 'false'))
         killasgroup = boolean(get(section, 'killasgroup', stopasgroup))
         exitcodes = list_of_exitcodes(get(section, 'exitcodes', '0'))
+        exit_supervisord = boolean(get(section, 'exit_supervisord', 'false'))
         # see also redirect_stderr check in process_groups_from_parser()
         redirect_stderr = boolean(get(section, 'redirect_stderr','false'))
         numprocs = integer(get(section, 'numprocs', 1))
@@ -1031,6 +1032,7 @@ class ServerOptions(Options):
                 stopasgroup=stopasgroup,
                 killasgroup=killasgroup,
                 exitcodes=exitcodes,
+                exit_supervisord=exit_supervisord,
                 redirect_stderr=redirect_stderr,
                 environment=environment,
                 serverurl=serverurl)
@@ -1853,7 +1855,7 @@ class ProcessConfig(Config):
         'stderr_logfile_backups', 'stderr_logfile_maxbytes',
         'stderr_events_enabled', 'stderr_syslog',
         'stopsignal', 'stopwaitsecs', 'stopasgroup', 'killasgroup',
-        'exitcodes', 'redirect_stderr' ]
+        'exitcodes', 'exit_supervisord', 'redirect_stderr' ]
     optional_param_names = [ 'environment', 'serverurl' ]
 
     def __init__(self, options, **params):

--- a/supervisor/tests/base.py
+++ b/supervisor/tests/base.py
@@ -524,7 +524,7 @@ class DummyPConfig:
                  stderr_syslog=False,
                  redirect_stderr=False,
                  stopsignal=None, stopwaitsecs=10, stopasgroup=False, killasgroup=False,
-                 exitcodes=(0,), environment=None, serverurl=None):
+                 exitcodes=(0,), exit_supervisord=False, environment=None, serverurl=None):
         self.options = options
         self.name = name
         self.command = command
@@ -555,6 +555,7 @@ class DummyPConfig:
         self.stopasgroup = stopasgroup
         self.killasgroup = killasgroup
         self.exitcodes = exitcodes
+        self.exit_supervisord = exit_supervisord
         self.environment = environment
         self.directory = directory
         self.umask = umask

--- a/supervisor/tests/test_options.py
+++ b/supervisor/tests/test_options.py
@@ -3223,7 +3223,7 @@ class ProcessConfigTests(unittest.TestCase):
                      'stderr_logfile', 'stderr_capture_maxbytes',
                      'stderr_events_enabled', 'stderr_syslog',
                      'stopsignal', 'stopwaitsecs', 'stopasgroup',
-                     'killasgroup', 'exitcodes', 'redirect_stderr',
+                     'killasgroup', 'exitcodes', 'exit_supervisord', 'redirect_stderr',
                      'environment'):
             defaults[name] = name
         for name in ('stdout_logfile_backups', 'stdout_logfile_maxbytes',
@@ -3321,7 +3321,7 @@ class EventListenerConfigTests(unittest.TestCase):
                      'stderr_logfile', 'stderr_capture_maxbytes',
                      'stderr_events_enabled', 'stderr_syslog',
                      'stopsignal', 'stopwaitsecs', 'stopasgroup',
-                     'killasgroup', 'exitcodes', 'redirect_stderr',
+                     'killasgroup', 'exitcodes', 'exit_supervisord', 'redirect_stderr',
                      'environment'):
             defaults[name] = name
         for name in ('stdout_logfile_backups', 'stdout_logfile_maxbytes',
@@ -3369,7 +3369,7 @@ class FastCGIProcessConfigTests(unittest.TestCase):
                      'stderr_logfile', 'stderr_capture_maxbytes',
                      'stderr_events_enabled', 'stderr_syslog',
                      'stopsignal', 'stopwaitsecs', 'stopasgroup',
-                     'killasgroup', 'exitcodes', 'redirect_stderr',
+                     'killasgroup', 'exitcodes', 'exit_supervisord', 'redirect_stderr',
                      'environment'):
             defaults[name] = name
         for name in ('stdout_logfile_backups', 'stdout_logfile_maxbytes',

--- a/supervisor/tests/test_supervisord.py
+++ b/supervisor/tests/test_supervisord.py
@@ -398,7 +398,7 @@ class SupervisordTests(unittest.TestCase):
                 'stopsignal': None, 'stopwaitsecs': 10,
                 'stopasgroup': False,
                 'killasgroup': False,
-                'exitcodes': (0,), 'environment': None, 'serverurl': None,
+                'exitcodes': (0,), 'exit_supervisord': False, 'environment': None, 'serverurl': None,
             }
             result.update(params)
             return ProcessConfig(options, **result)
@@ -464,7 +464,7 @@ class SupervisordTests(unittest.TestCase):
                 'stopsignal': None, 'stopwaitsecs': 10,
                 'stopasgroup': False,
                 'killasgroup': False,
-                'exitcodes': (0,), 'environment': None, 'serverurl': None,
+                'exitcodes': (0,), 'exit_supervisord': False, 'environment': None, 'serverurl': None,
             }
             result.update(params)
             return EventListenerConfig(options, **result)


### PR DESCRIPTION
…ured processes

Instead of writing an event listener, the following new config is an alternative and is perhaps simpler to setup.  