### PR TITLE
Option to add directory

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -312,10 +312,9 @@ class Options:
         """Process configuration data structure.
 
         This includes reading config file if necessary, setting defaults etc.
-        """
+        """        
         if self.configfile:
-            self.process_config_file(do_usage)
-
+            self.process_config_file(do_usage)        
         # Copy config options to attributes of self.  This only fills
         # in options that aren't already set from the command line.
         for name, confname in self.names_list:
@@ -484,7 +483,7 @@ class ServerOptions(Options):
     def realize(self, *arg, **kw):
         Options.realize(self, *arg, **kw)
         section = self.configroot.supervisord
-
+        
         # Additional checking of user option; set uid and gid
         if self.user is not None:
             try:
@@ -520,6 +519,7 @@ class ServerOptions(Options):
         self.serverurl = None
 
         self.server_configs = sconfigs = section.server_configs
+        self.directories = section.directories
 
         # we need to set a fallback serverurl that process.spawn can use
 
@@ -670,6 +670,7 @@ class ServerOptions(Options):
                 env.update(proc.environment)
                 proc.environment = env
         section.server_configs = self.server_configs_from_parser(parser)
+        section.directories = self.directories_from_parser(parser)        
         section.profile_options = None
         return section
 
@@ -1132,6 +1133,29 @@ class ServerOptions(Options):
 
         return configs
 
+    def directories_from_parser(self, parser):
+        """Read [directory:x] sections from parser."""
+        get = parser.saneget
+        directories = []
+        all_sections = parser.sections()
+        for section in all_sections:
+            if not section.startswith('directory:'):
+                continue
+            name = section.split(':', 1)[1]
+            path = get(section, "path", None)
+            if path is None:
+                raise ValueError('[%s] section requires a value for "path"')
+            path = normalize_path(path)
+            create = boolean(get(section, "create", "false"))
+            mode_str = get(section, "mode", "777")
+            try:               
+                mode = octal_type(mode_str)
+            except (TypeError, ValueError):
+                raise ValueError("Invalid mode value %s" % mode_str)
+            directory = DirectoryConfig(name, path, create, mode)
+            directories.append(directory)        
+        return directories
+
     def daemonize(self):
         self.poller.before_daemonize()
         self._daemonize()
@@ -1496,7 +1520,19 @@ class ServerOptions(Options):
             self.logger.warn(msg)
         for msg in self.parse_infos:
             self.logger.info(msg)
-
+    
+    def check_directories(self):
+        # must be called after realize() and after supervisor does setuid()
+        for directory in self.directories:            
+            try:
+                if directory.verify_exists():
+                    self.logger.info(
+                        "created directory (%s) %s"
+                        % (directory.name, directory.path)
+                    )
+            except ValueError as error:
+                self.usage(str(error))            
+                
     def make_http_servers(self, supervisord):
         from supervisor.http import make_http_servers
         return make_http_servers(self, supervisord)
@@ -2059,6 +2095,51 @@ class FastCGIGroupConfig(ProcessGroupConfig):
     def make_group(self):
         from supervisor.process import FastCGIProcessGroup
         return FastCGIProcessGroup(self)
+
+
+class DirectoryConfig(object):
+    """Configuration for a required directory."""
+
+    def __init__(self, name, path, create, mode):
+        self.name = name
+        self.path = path
+        self.create = create
+        self.mode = mode 
+
+    def __repr__(self):
+        return "DirectoryConfig({!r}, {!r}, {!r}, 0o{:o})".format(
+            self.name, self.path, self.create, self.mode
+        )
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, DirectoryConfig)
+            and self.name == other.name
+            and self.path == other.path
+            and self.create == other.create
+            and self.mode == other.mode
+        )
+
+    def verify_exists(self):
+        """Verify the directory exists, and potentially try to
+        create it. Return True if directory was created."""        
+        if os.path.exists(self.path):            
+            if not os.path.isdir(self.path):             
+                raise ValueError(
+                    "required directory (%s) %s is not a directory"
+                    % (self.name, self.path)
+                )
+        else:            
+            if self.create:                            
+                os.makedirs(self.path, self.mode)
+                return True
+            else:                
+                raise ValueError(
+                    "required directory (%s) %s does not exist"
+                    % (self.name, self.path)
+                )        
+        return False        
+
 
 def readFile(filename, offset, length):
     """ Read length bytes from the file named by filename starting at

--- a/supervisor/supervisord.py
+++ b/supervisor/supervisord.py
@@ -62,7 +62,7 @@ class Supervisor:
             # first request
             self.options.cleanup_fds()
 
-        self.options.set_uid_or_exit()
+        self.options.set_uid_or_exit()        
 
         if self.options.first:
             self.options.set_rlimits_or_exit()
@@ -70,6 +70,8 @@ class Supervisor:
         # this sets the options.logger object
         # delay logger instantiation until after setuid
         self.options.make_logger()
+
+        self.options.check_directories()
 
         if not self.options.nocleanup:
             # clean up old automatic logs

--- a/supervisor/tests/base.py
+++ b/supervisor/tests/base.py
@@ -133,6 +133,9 @@ class DummyOptions:
     def make_logger(self):
         pass
 
+    def check_directories(self):
+        pass
+
     def clear_autochildlogdir(self):
         self.autochildlogdir_cleared = True
 

--- a/supervisor/tests/test_options.py
+++ b/supervisor/tests/test_options.py
@@ -9,6 +9,7 @@ import signal
 import shutil
 import errno
 import platform
+import tempfile
 
 from supervisor.compat import StringIO
 from supervisor.compat import as_bytes
@@ -3255,13 +3256,36 @@ class ServerOptionsTests(unittest.TestCase):
         msg = instance.drop_privileges(42)
         self.assertEqual(msg, "Can't drop privilege as nonroot user")
 
-    def test_daemonize_notifies_poller_before_and_after_fork(self):
+    def test_directories_from_parser(self):
+        from supervisor.options import DirectoryConfig
+        text = lstrip("""\
+        [directory:dir1]
+        path = /foo/bar
+        
+        [directory:dir2]
+        path = /foo/new
+        create = True
+
+        [directory:dir3]
+        path = /foo/new2
+        create = True
+        mode = 755
+        """)
+        from supervisor.options import UnhosedConfigParser
+        config = UnhosedConfigParser()
+        config.read_string(text)
         instance = self._makeOne()
-        instance._daemonize = lambda: None
-        instance.poller = Mock()
-        instance.daemonize()
-        instance.poller.before_daemonize.assert_called_once_with()
-        instance.poller.after_daemonize.assert_called_once_with()
+        directories = instance.directories_from_parser(config)        
+
+        self.assertEqual(
+            directories,
+            [
+                DirectoryConfig('dir1', '/foo/bar', False, 0o777),
+                DirectoryConfig('dir2', '/foo/new', True, 0o777),
+                DirectoryConfig('dir3', '/foo/new2', True, 0o755)
+            ]
+        )
+        
 
 class ProcessConfigTests(unittest.TestCase):
     def _getTargetClass(self):
@@ -3731,6 +3755,82 @@ class UtilFunctionsTests(unittest.TestCase):
         self.assertEqual(s('process'), ('process', 'process'))
         self.assertEqual(s('group:'), ('group', None))
         self.assertEqual(s('group:*'), ('group', None))
+
+
+class TestDirectories(unittest.TestCase):
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp("supervisor", "testdir")
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def test_repr(self):
+        from supervisor.options import DirectoryConfig
+        directory_config = DirectoryConfig(
+            "foo",
+            "/foo/bar",
+            True,
+            0o777
+        )
+        self.assertEqual(
+            repr(directory_config),
+            "DirectoryConfig('foo', '/foo/bar', True, 0o777)"
+        )
+    
+    def check_directory_exists(self):
+        from supervisor.options import DirectoryConfig            
+        directory_config = DirectoryConfig(
+            "foo",
+            self.temp_dir,
+            False,
+            0o777
+        )
+        # Should return false if directory exists and isn't created in the check
+        self.assertFalse(directory_config.verify_exists())
+
+    def check_directory_does_not_exist(self):
+        from supervisor.options import DirectoryConfig    
+        directory = os.path.join(self.temp_dir, "nothing_here")   
+        directory_config = DirectoryConfig(
+            "foo",
+            directory,
+            False,
+            0o777
+        )
+        with self.assertRaises(ValueError):
+            # Directory doesn't exist, should raise ValueError
+            directory_config.verify_exists()
+
+    def check_directory_not_a_directory(self):
+        from supervisor.options import DirectoryConfig    
+        directory = os.path.join(self.temp_dir, "foo")
+        with open(directory, "w") as fh:
+            fh.write("test")
+        directory_config = DirectoryConfig(
+            "foo",
+            directory,
+            False,
+            0o777
+        )
+        with self.assertRaises(ValueError):
+            # Path exists, but not a directory
+            directory_config.verify_exists()
+
+    def check_create(self):
+        from supervisor.options import DirectoryConfig        
+        directory = os.path.join(self.temp_dir, "foo/bar")
+        self.assertFalse(os.path.exists(directory))
+        directory_config = DirectoryConfig(
+            "foo",
+            directory,
+            True,
+            0o777
+        )
+        # With create = True, the directory will be created
+        self.assertTrue(directory_config.verify_exists())
+        self.assertTrue(os.path.isdir(directory))
+
 
 def test_suite():
     return unittest.findTestCases(sys.modules[__name__])


### PR DESCRIPTION
This is an attempt to resolve https://github.com/Supervisor/supervisor/issues/120 

I'm looking for early feedback. Happy to make any changes if there is an agreement on the idea, and I can update the docs. BTW this work is sponsored by my client :)

The gist is that there would be a new section in the configuration that would check if a directory exists, and optionally create it. Here's an example:

```
[directory:foo]
path = /foo/bar
create = True
mode = 777
```

Only `path` is required. If `create` is True, the directory will be created if it doesn't already exist. If `create` is False (the default), then it will fail if the directory doesn't exist.

Should the directory config have a `chown` value to set ownership of the new directory?