### PR TITLE
Ignore current uid when dropping privileges

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -1372,6 +1372,11 @@ class ServerOptions(Options):
             # has "user=foo" (same user) in it.
             return
 
+        try:
+            os.setuid(uid)
+        except:
+            return 'Could not set user id of effective user'
+
         gid = pwrec[3]
         if hasattr(os, 'setgroups'):
             user = pwrec[0]
@@ -1392,11 +1397,6 @@ class ServerOptions(Options):
             os.setgid(gid)
         except OSError:
             return 'Could not set group id of effective user'
-
-        try:
-            os.setuid(uid)
-        except:
-            return 'Could not set user id of effective user'
 
     def set_uid_or_exit(self):
         """Set the uid of the supervisord process.  Called during supervisord

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -1396,7 +1396,7 @@ class ServerOptions(Options):
         try:
             os.setuid(uid)
         except:
-            return 'Could not set effective user id'
+            return 'Could not set user id of effective user'
 
     def set_uid_or_exit(self):
         """Set the uid of the supervisord process.  Called during supervisord

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -1372,11 +1372,6 @@ class ServerOptions(Options):
             # has "user=foo" (same user) in it.
             return
 
-        try:
-            os.setuid(uid)
-        except:
-            return 'Could not set user id of effective user'
-
         gid = pwrec[3]
         if hasattr(os, 'setgroups'):
             user = pwrec[0]
@@ -1397,6 +1392,11 @@ class ServerOptions(Options):
             os.setgid(gid)
         except OSError:
             return 'Could not set group id of effective user'
+
+        try:
+            os.setuid(uid)
+        except:
+            return 'Could not set user id of effective user'
 
     def set_uid_or_exit(self):
         """Set the uid of the supervisord process.  Called during supervisord

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -1372,9 +1372,6 @@ class ServerOptions(Options):
             # has "user=foo" (same user) in it.
             return
 
-        if current_uid != 0:
-            return "Can't drop privilege as nonroot user"
-
         gid = pwrec[3]
         if hasattr(os, 'setgroups'):
             user = pwrec[0]
@@ -1395,7 +1392,11 @@ class ServerOptions(Options):
             os.setgid(gid)
         except OSError:
             return 'Could not set group id of effective user'
-        os.setuid(uid)
+
+        try:
+            os.setuid(uid)
+        except:
+            return 'Could not set effective user id'
 
     def set_uid_or_exit(self):
         """Set the uid of the supervisord process.  Called during supervisord

--- a/supervisor/tests/test_options.py
+++ b/supervisor/tests/test_options.py
@@ -3253,7 +3253,7 @@ class ServerOptionsTests(unittest.TestCase):
     def test_drop_privileges_nonroot_different_user(self):
         instance = self._makeOne()
         msg = instance.drop_privileges(42)
-        self.assertEqual(msg, "Can't drop privilege as nonroot user")
+        self.assertEqual(msg, "Could not set user id of effective user")
 
     def test_daemonize_notifies_poller_before_and_after_fork(self):
         instance = self._makeOne()

--- a/supervisor/tests/test_options.py
+++ b/supervisor/tests/test_options.py
@@ -3253,7 +3253,7 @@ class ServerOptionsTests(unittest.TestCase):
     def test_drop_privileges_nonroot_different_user(self):
         instance = self._makeOne()
         msg = instance.drop_privileges(42)
-        self.assertEqual(msg, "Could not set user id of effective user")
+        self.assertEqual(msg, "Could not set group id of effective user")
 
     def test_daemonize_notifies_poller_before_and_after_fork(self):
         instance = self._makeOne()


### PR DESCRIPTION
**Problem**:
If starting the process as a different user from supervisor then it is mandatory to run supervisor as root. This is because the current code checks for supervisor uid=0 i.e. root. However, on Linux systems, it is sufficient to have cap_setuid and cap_setgid to set effective user and group ids. 

**Solution**:
Instead of checking for root UID (i.e. 0), it is sufficient to check the exception from setuid. 

**Scenario**:
From supervisor start a process that runs with a different user account.
If running with privileged user i.e. root, -> success
If running supervisor as an unprivileged user,
a) with no capabilities -> fails
b) with capability cap_setuid alone -> fails
c) with capability cap_setgid alone -> fails
d) with capabilities cap_setuid and cap_setgid both -> succeeds
