### PR TITLE
Stop running tests when building the documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,14 +22,6 @@ from datetime import date
 
 parent = os.path.dirname(os.path.dirname(__file__))
 sys.path.append(os.path.abspath(parent))
-wd = os.getcwd()
-os.chdir(parent)
-os.system('%s setup.py test -q' % sys.executable)
-os.chdir(wd)
-
-for item in os.listdir(parent):
-    if item.endswith('.egg'):
-        sys.path.append(os.path.join(parent, item))
 
 version_txt = os.path.join(parent, 'supervisor/version.txt')
 supervisor_version = open(version_txt).read().strip()


### PR DESCRIPTION
Hi,
I got slightly confused when I noticed that building the documentation triggered a test run.

This reverts part of 674109eadc61943c593044d1375a0e8f159ae2ed which added the call to `setup.py test`, let me know if I missed something important but I don't see any reason to keep this weird behaviour.