### PR TITLE
kwargs not supported by pythons xmlrpc.client

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -27,7 +27,9 @@ is as follows.
 
 You may call methods against :program:`supervisord` and its
 subprocesses by using the ``supervisor`` namespace.  An example is
-provided below.
+provided below. Please note that keyword arguments are not
+supported in Python's xmlrpc library and therefore cannot be 
+used e.g. in :ref:`startProcess`.
 
 .. code-block:: python
 


### PR DESCRIPTION
It seems that kwargs are not supported by the xmlrpc library:

https://github.com/python/cpython/blob/b04f1cb9df7ad93366ef0ef7d8088effc576c5ae/Lib/xmlrpc/client.py#L1115

Too bad, because then you cannot use the `wait` named parameter. I just found that out the hard way, would be useful to quickly state thin in the docs I think.