### PR TITLE
New feature to allow the program environment to be loaded from an ext…

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -464,6 +464,42 @@ follows.
 
   *Introduced*: 3.0
 
+``environment_file``
+
+  An absolute path to a file that contains a ``KEY=VAL`` entry on each line.
+  Lines that begin with a '#' character are ignored. Leading and trailing
+  whitespace are stripped off. Each valid ``KEY=VAL`` line will be placed
+  in the environment of all child processes. The VAL entries must not be quoted,
+  and interpolation is not supported for these values. The file must be readable
+  by supervisord, and may be only readable by the user supervisord runs as since
+  these values are loaded before any privileges are dropped for child processes.
+  All other behaviors of the ``environment`` values are followed. When this is
+  set in the supervisord section, it will be applied to all program sections unless
+  they explicitly set either ``environment_file`` or ``environment_loader``. Only one of
+  the program setting or the supervisord setting for environment_file is processed.
+
+  *Default*: no value
+
+  *Required*:  No.
+
+  *Introduced*: 4.2.3
+
+``environment_loader``
+
+  A shell command or an absolute path to a program that will be run by supervisord before launching
+  the child processes, and the stdout will be captured and parsed according to the rules for
+  ``environment_file``.  Only one of ``environment_file`` or ``environment_loader`` should be set, and
+  ``environment_file`` takes precedence. When this is set in the supervisord section,
+  it will be applied to all program sections unless they explicitly set either
+  ``environment_file`` or ``environment_loader``. Only one of the program setting or the
+  supervisord setting for environment_loader is processed.
+
+  *Default*: no value
+
+  *Required*:  No.
+
+  *Introduced*: 4.2.3
+
 ``identifier``
 
   The identifier string for this supervisor process, used by the RPC
@@ -1098,6 +1134,37 @@ where specified.
   *Required*:  No.
 
   *Introduced*: 3.0
+
+``environment_file``
+
+  An absolute path to a file that contains a ``KEY=VAL`` entry on each line.
+  Lines that begin with a '#' character are ignored. Leading and trailing
+  whitespace between the values are stripped off. Each valid ``KEY=VAL`` line will be placed
+  in the environment of all child processes. The VAL entries must not be quoted,
+  and interpolation is not supported for these values. The file must be readable
+  by supervisord, and may be only readable by the user supervisord runs as since
+  these values are loaded before any privileges are dropped for child processes.
+  All other behaviors of the ``environment`` values are followed.
+
+  *Default*: no value
+
+  *Required*:  No.
+
+  *Introduced*: 4.2.3
+
+``environment_loader``
+
+  A shell command or an absolute path to a program that will be by supervisord before launching
+  a child process, and the stdout will be captured and parsed according to the rules for
+  ``environment_file``. The program must be executable by supervisord. Only one of
+  ``environment_file`` or ``environment_loader`` should be set, and ``environment_file`` takes precedence.
+
+  *Default*: no values
+
+  *Required*:  No.
+
+  *Introduced*: 4.2.3
+
 
 ``directory``
 

--- a/supervisor/tests/base.py
+++ b/supervisor/tests/base.py
@@ -520,7 +520,8 @@ class DummyPConfig:
                  stderr_syslog=False,
                  redirect_stderr=False,
                  stopsignal=None, stopwaitsecs=10, stopasgroup=False, killasgroup=False,
-                 exitcodes=(0,), environment=None, serverurl=None):
+                 exitcodes=(0,), environment=None, environment_file=None, environment_loader=None,
+                 serverurl=None):
         self.options = options
         self.name = name
         self.command = command
@@ -552,6 +553,8 @@ class DummyPConfig:
         self.killasgroup = killasgroup
         self.exitcodes = exitcodes
         self.environment = environment
+        self.environment_file = environment_file
+        self.environment_loader = environment_loader
         self.directory = directory
         self.umask = umask
         self.autochildlogs_created = False
@@ -581,6 +584,10 @@ class DummyPConfig:
         if stdin_fd is not None:
             dispatchers[stdin_fd] = DummyDispatcher(writable=True)
         return dispatchers, pipes
+
+    def load_external_environment_definition(self):
+        from supervisor.options import ProcessConfig
+        return ProcessConfig.load_external_environment_definition_for_config(self)
 
 def makeExecutable(file, substitutions=None):
     import os


### PR DESCRIPTION
…ernal file or program.

- This allows supervisord to be used in conjunction with any secrets
pattern using a root-only file or a program that can provide environment
variables that a program should have. It can be set globally in the
supervisord section, or per program in a program section. The new
options are environment_file or environment_loader. They are optional,
and errors in one of them will prevent startup. They can be set in the
[supervisord] section and then will be passed down to the programs, or
in the program definitions. The file/loader is checked right before the
calls to spawn() in order to avoid problems with calling a subprocess
after the child fork, and to allow restarts to reload those environment
values.
- Updated the docs for these new options
- Updated the tests to add a new test to check these new options.


From researching the history of things similar to this feature, I'm pretty sure the supervisor team will reject this and doesn't want it. But, it's a critical feature I need to move forward with supervisor. I've been a happy user for years now, but in needing to modernize some old stacks I need functionality like this. Lots of others agree, so hopefully this will be useful to them as well. I'll be running this fork for the foreseeable future and others are welcome to grab it and use it. Supervisor is pretty much feature complete for me so I'll only update it as necessary. The changes are pretty simple and easy to maintain, so hopefully this will be accepted. I did figure out how to add tests and run them with tox and they are all passing on both python 2.7 and 3.8.