### PR TITLE
feature: add support for runningregex to set RUNNING state accordingly

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -935,7 +935,7 @@ class ServerOptions(Options):
         runningregex = get(section, 'runningregex', None)
         if runningregex:
             try:
-                runningregex = re.compile(runningregex)
+                runningregex = re.compile(r'.*'+ runningregex)
             except Exception as e:
                 raise ValueError(
                     f"program section {section} has invalid runningregex value. Error {e}")

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -932,6 +932,14 @@ class ServerOptions(Options):
         serverurl = get(section, 'serverurl', None)
         if serverurl and serverurl.strip().upper() == 'AUTO':
             serverurl = None
+        runningregex = get(section, 'runningregex', None)
+        if runningregex:
+            try:
+                runningregex = re.compile(runningregex)
+            except Exception as e:
+                raise ValueError(
+                    f"program section {section} has invalid runningregex value. Error {e}")
+
 
         # find uid from "user" option
         user = get(section, 'user', None)
@@ -1057,7 +1065,9 @@ class ServerOptions(Options):
                 exitcodes=exitcodes,
                 redirect_stderr=redirect_stderr,
                 environment=environment,
-                serverurl=serverurl)
+                serverurl=serverurl,
+                runningregex=runningregex
+            )
 
             programs.append(pconfig)
 
@@ -1875,7 +1885,7 @@ class ProcessConfig(Config):
         'stderr_events_enabled', 'stderr_syslog',
         'stopsignal', 'stopwaitsecs', 'stopasgroup', 'killasgroup',
         'exitcodes', 'redirect_stderr' ]
-    optional_param_names = [ 'environment', 'serverurl' ]
+    optional_param_names = [ 'environment', 'serverurl', 'runningregex' ]
 
     def __init__(self, options, **params):
         self.options = options

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -939,7 +939,12 @@ class ServerOptions(Options):
             except Exception as e:
                 raise ValueError(
                     f"program section {section} has invalid runningregex value. Error {e}")
-
+            if "/dev/" in get(section, 'stdout_logfile'):
+                self.warnings.warn(
+                    '\033[93m runningregex is only supported for logfiles.'
+                    'It does not work with /dev/null or /dev/fd/1.'
+                    'Startsecs are used instead \033[0m')
+                runningregex = None
 
         # find uid from "user" option
         user = get(section, 'user', None)

--- a/supervisor/process.py
+++ b/supervisor/process.py
@@ -5,6 +5,7 @@ import signal
 import shlex
 import time
 import traceback
+import re
 
 from supervisor.compat import maxint
 from supervisor.compat import as_bytes
@@ -698,6 +699,10 @@ class Subprocess(object):
 
                 from supervisor.options import readFile
                 str =  as_string(readFile(logfile, 0, 0))
+                
+                # delete ascii escape sequence and newlines with regular expression
+                ansi_escape = re.compile(r'(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]|\n')
+                str = ansi_escape.sub('', str)
 
                 if self.config.runningregex.match(str):
                     # STARTING -> RUNNING if the proc has started


### PR DESCRIPTION
The runningregex option can be used to only set the RUNNING state of a process, if the child process is considered to be running. This is done by looking into the stdout and check whether an expected output has been recognized. If so, the process will set to running state. This requires the child process to create the corresponding output, otherwise the RUNNING state is never reached.

Closes #1445 

This option can be used by adding runningregex to the config of a program.  

In the following minimal example, the running state will be set when "Hello World!" is printed. 
[program:hello_world] 
command = /bin/sh -c  "sleep 10 && echo Hello World! && sleep 10" 
runningregex=Hello
stdout_logfile=./log/hello_world.log