### PR TITLE
setup.py: add setuptools to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ if py_version < (2, 7):
 elif (3, 0) < py_version < (3, 4):
     raise RuntimeError('On Python 3, Supervisor requires Python 3.4 or later')
 
-requires = []
+# pkg_resource is used in several places
+requires = ["setuptools"]
 tests_require = []
 if py_version < (3, 3):
     tests_require.append('mock<4.0.0.dev0')


### PR DESCRIPTION
Hi,
I am adding it because `pkg_resource` is used by several installed files.

Initially reported in https://bugs.gentoo.org/813300 (where it appeared that the package didn't require setuptools at runtime).