### PR TITLE
Use context managers and stop using bare `Except`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,10 @@ testing_extras = tests_require + [
 from setuptools import setup, find_packages
 here = os.path.abspath(os.path.dirname(__file__))
 try:
-    README = open(os.path.join(here, 'README.rst')).read()
-    CHANGES = open(os.path.join(here, 'CHANGES.rst')).read()
+    with open(os.path.join(here, 'README.rst'), 'r') as f:
+        README = f.read()
+    with open(os.path.join(here, 'CHANGES.rst'), 'r') as f:
+        CHANGES = f.read()
 except Exception:
     README = """\
 Supervisor is a client/server system that allows its users to
@@ -65,7 +67,8 @@ CLASSIFIERS = [
 ]
 
 version_txt = os.path.join(here, 'supervisor/version.txt')
-supervisor_version = open(version_txt).read().strip()
+with open(version_txt, 'r') as f:
+    supervisor_version = f.read().strip()
 
 dist = setup(
     name='supervisor',


### PR DESCRIPTION
As I was adding the context managers I also noticed the bare `Except:`. If there's an explicit reason for it please let me know.