### PR TITLE
identifier set in command line overwritten by default value

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -543,8 +543,6 @@ class ServerOptions(Options):
         # self.serverurl may still be None if no servers at all are
         # configured in the config file
 
-        self.identifier = section.identifier
-
     def process_config(self, do_usage=True):
         Options.process_config(self, do_usage=do_usage)
 


### PR DESCRIPTION
the Supervisor identifier may have been set in the command line and not in the configuration file.
the last line of ServerOptions.realize systematically overwrites the self.identifier by the value from the configuration file (that may be the default one 'supervisor').
if the identifier was set in the configuration file, the self.identifier was already updated.
so there's no point keeping this line.