### PR TITLE
Tell user which default config file was chosen

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -128,6 +128,7 @@ class Options:
         for path in self.searchpaths:
             if os.path.exists(path):
                 config = path
+                self.stdout.write("Chose default config file: %s\n" % config)
                 break
         if config is None and self.require_configfile:
             self.usage('No config file found at default paths (%s); '


### PR DESCRIPTION
Hi. Thanks for allowing the user to have a default `supervisord.conf` file, which allows us to reduce the command line clutter of the supervisor* executables. It's very convenient!

However, it is a little perilous because the user doesn't know which default file was chosen, since there are 6 options for default files. e.g., if I'm accustomed to using the lowest-priority default file, and somebody adds a higher-priority default file to my filesystem without telling me, it could ruin my day.

Here's a MR which simply tells the user which default config file is chosen, if the `-c` option is excluded. I'm not sure if the developers prefer to use `self.stdout.write` here, or something else. I'm open to suggestion.

Thanks!


cf:

https://github.com/Supervisor/supervisor/blob/master/supervisor/options.py

```
        searchpaths = [os.path.join(here, 'etc', 'supervisord.conf'),
                       os.path.join(here, 'supervisord.conf'),
                       'supervisord.conf',
                       'etc/supervisord.conf',
                       '/etc/supervisord.conf',
                       '/etc/supervisor/supervisord.conf',
                       ]
```