### PR TITLE
docs(api): add `getAllConfigInfo`

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -321,6 +321,8 @@ Process Control
         same elements as the struct returned by ``getProcessInfo``. If the process
         table is empty, an empty array is returned.
 
+    .. automethod:: getAllConfigInfo
+
     .. automethod:: startProcess
 
     .. automethod:: startAllProcesses


### PR DESCRIPTION
Seems like the documentation for [getAllConfigInfo](https://github.com/Supervisor/supervisor/blob/8b83afdac70f140787fdb160d930f824a1f90a33/supervisor/rpcinterface.py#L558) is missing.