### PR TITLE
Add changelog URL to package metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,9 @@ dist = setup(
     version=supervisor_version,
     license='BSD-derived (http://www.repoze.org/LICENSE.txt)',
     url='http://supervisord.org/',
+    project_urls={
+        'Changelog': 'http://supervisord.org/changes.html',
+    },
     description="A system for controlling process state under UNIX",
     long_description=README + '\n\n' + CHANGES,
     classifiers=CLASSIFIERS,
@@ -87,7 +90,7 @@ dist = setup(
     install_requires=requires,
     extras_require={
         'testing': testing_extras,
-        },
+    },
     tests_require=tests_require,
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
When [Renovate bot](https://docs.renovatebot.com/) creates an automated pull request to update supervisord, it can automatically include the link to changelog so it's easier to find out what changed.

The URL name has to be one of: 'changelog', 'change log', 'changes', 'release notes', 'news', "what's new" (case insensitive). Source: https://github.com/renovatebot/renovate/blob/c3a87b687ed44a1a100e0e4f91b81e22b7c32482/lib/modules/datasource/pypi/index.ts#L130-L140
