### PR TITLE
Replace runtime dependency on setuptools with modern libraries

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1478,9 +1478,9 @@ sections do not have.
 
 ``result_handler``
 
-  A `pkg_resources entry point string
-  <http://peak.telecommunity.com/DevCenter/PkgResources>`_ that
-  resolves to a Python callable.  The default value is
+  An `entry point object reference
+  <https://packaging.python.org/en/latest/specifications/entry-points/#data-model>`_
+  string that resolves to a Python callable.  The default value is
   ``supervisor.dispatchers:default_handler``.  Specifying an alternate
   result handler is a very uncommon thing to need to do, and as a
   result, how to create one is not documented.
@@ -1581,7 +1581,7 @@ And a section in the config file meant to configure it.
 
 ``supervisor.rpcinterface_factory``
 
-  ``pkg_resources`` "entry point" dotted name to your RPC interface's
+  ``entry point object reference`` dotted name to your RPC interface's
   factory function.
 
   *Default*: N/A

--- a/docs/events.rst
+++ b/docs/events.rst
@@ -93,9 +93,9 @@ follows.
 
    An advanced feature, specifying an alternate "result handler" for a
    pool, can be specified via the ``result_handler`` parameter of an
-   ``[eventlistener:x]`` section in the form of a `pkg_resources
-   <http://peak.telecommunity.com/DevCenter/PkgResources>`_ "entry
-   point" string.  The default result handler is
+   ``[eventlistener:x]`` section in the form of an `entry point object reference
+   <https://packaging.python.org/en/latest/specifications/entry-points/#data-model>`_
+   string.  The default result handler is
    ``supervisord.dispatchers:default_handler``.  Creating an alternate
    result handler is not currently documented.
 
@@ -897,4 +897,3 @@ Indicates that a process group has been removed from Supervisor's configuration.
 .. code-block:: text
 
    groupname:cat
-

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,10 @@ if py_version < (2, 7):
 elif (3, 0) < py_version < (3, 4):
     raise RuntimeError('On Python 3, Supervisor requires Python 3.4 or later')
 
-# pkg_resource is used in several places
-requires = ["setuptools"]
+requires = [
+    "importlib-metadata; python_version < '3.8'",
+    "importlib-resources; python_version < '3.9'",
+]
 tests_require = []
 if py_version < (3, 3):
     tests_require.append('mock<4.0.0.dev0')

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ elif (3, 0) < py_version < (3, 4):
 
 requires = [
     "importlib-metadata; python_version < '3.8'",
-    "importlib-resources; python_version < '3.9'",
+    "importlib-resources; python_version < '3.7'",
 ]
 tests_require = []
 if py_version < (3, 3):

--- a/supervisor/confecho.py
+++ b/supervisor/confecho.py
@@ -1,7 +1,12 @@
-import pkg_resources
 import sys
 from supervisor.compat import as_string
 
+if sys.version_info >= (3, 9):
+    from importlib.resources import files as resource_files
+else:
+    from importlib_resources import files as resource_files
+
+
 def main(out=sys.stdout):
-    config = pkg_resources.resource_string(__name__, 'skel/sample.conf')
+    config = resource_files(__package__).joinpath('skel/sample.conf').read_text(encoding='utf-8')
     out.write(as_string(config))

--- a/supervisor/confecho.py
+++ b/supervisor/confecho.py
@@ -1,12 +1,8 @@
 import sys
+from supervisor import resources
 from supervisor.compat import as_string
-
-if sys.version_info >= (3, 9):
-    from importlib.resources import files as resource_files
-else:
-    from importlib_resources import files as resource_files
 
 
 def main(out=sys.stdout):
-    config = resource_files(__package__).joinpath('skel/sample.conf').read_text(encoding='utf-8')
+    config = resources.read_text(__package__, 'skel/sample.conf')
     out.write(as_string(config))

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -10,7 +10,6 @@ import pwd
 import grp
 import resource
 import stat
-import pkg_resources
 import glob
 import platform
 import warnings
@@ -54,6 +53,12 @@ from supervisor import loggers
 from supervisor import states
 from supervisor import xmlrpc
 from supervisor import poller
+
+if sys.version_info >= (3, 8):
+    from importlib.metadata import EntryPoint
+else:
+    from importlib_metadata import EntryPoint
+
 
 def _read_version_txt():
     mydir = os.path.abspath(os.path.dirname(__file__))
@@ -377,7 +382,7 @@ class Options:
                                  (section, factory_key))
             try:
                 factory = self.import_spec(factory_spec)
-            except ImportError:
+            except (AttributeError, ImportError):
                 raise ValueError('%s cannot be resolved within [%s]' % (
                     factory_spec, section))
 
@@ -390,13 +395,7 @@ class Options:
         return factories
 
     def import_spec(self, spec):
-        ep = pkg_resources.EntryPoint.parse("x=" + spec)
-        if hasattr(ep, 'resolve'):
-            # this is available on setuptools >= 10.2
-            return ep.resolve()
-        else:
-            # this causes a DeprecationWarning on setuptools >= 11.3
-            return ep.load(False)
+        return EntryPoint(None, spec, None).load()
 
     def read_include_config(self, fp, parser, expansions):
         if parser.has_section('include'):
@@ -759,7 +758,7 @@ class ServerOptions(Options):
                                        'supervisor.dispatchers:default_handler')
             try:
                 result_handler = self.import_spec(result_handler)
-            except ImportError:
+            except (AttributeError, ImportError):
                 raise ValueError('%s cannot be resolved within [%s]' % (
                     result_handler, section))
 

--- a/supervisor/resources.py
+++ b/supervisor/resources.py
@@ -1,0 +1,40 @@
+import sys
+
+if sys.version_info >= (3, 9):
+    from importlib.resources import files
+
+
+    def read_text(package, path):
+        return files(package).joinpath(path).read_text(encoding='utf-8')
+
+
+    def find(package, path):
+        return str(files(package).joinpath(path))
+
+elif sys.version_info >= (3, 7):
+    import importlib.resources
+
+
+    def read_text(package, path):
+        with importlib.resources.path(package, '__init__.py') as p:
+            return p.parent.joinpath(path).read_text(encoding='utf-8')
+
+
+    def find(package, path):
+        with importlib.resources.path(package, '__init__.py') as p:
+            return str(p.parent.joinpath(path))
+
+else:
+    from io import open
+
+    import importlib_resources
+
+
+    def read_text(package, path):
+        with open(find(package, path), 'r', encoding='utf-8') as f:
+            return f.read()
+
+
+    def find(package, path):
+        with importlib_resources.path(package, '__init__.py') as p:
+            return str(p.parent.joinpath(path))

--- a/supervisor/tests/test_end_to_end.py
+++ b/supervisor/tests/test_end_to_end.py
@@ -5,13 +5,9 @@ import os
 import signal
 import sys
 import unittest
+from supervisor import resources
 from supervisor.compat import xmlrpclib
 from supervisor.xmlrpc import SupervisorTransport
-
-if sys.version_info >= (3, 9):
-    from importlib.resources import files as resource_files
-else:
-    from importlib_resources import files as resource_files
 
 # end-to-test tests are slow so only run them when asked
 if 'END_TO_END' in os.environ:
@@ -29,7 +25,7 @@ class EndToEndTests(BaseTestCase):
         passed to the child without the percent sign being mangled."""
         key = "SUPERVISOR_TEST_1441B"
         val = "foo_%s_%_%%_%%%_%2_bar"
-        filename = str(resource_files(__package__).joinpath('fixtures/issue-291a.conf'))
+        filename = resources.find(__package__, 'fixtures/issue-291a.conf')
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         try:
             os.environ[key] = val
@@ -42,7 +38,7 @@ class EndToEndTests(BaseTestCase):
     def test_issue_550(self):
         """When an environment variable is set in the [supervisord] section,
         it should be put into the environment of the subprocess."""
-        filename = str(resource_files(__package__).joinpath('fixtures/issue-550.conf'))
+        filename = resources.find(__package__, 'fixtures/issue-550.conf')
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -58,7 +54,7 @@ class EndToEndTests(BaseTestCase):
     def test_issue_565(self):
         """When a log file has Unicode characters in it, 'supervisorctl
         tail -f name' should still work."""
-        filename = str(resource_files(__package__).joinpath('fixtures/issue-565.conf'))
+        filename = resources.find(__package__, 'fixtures/issue-565.conf')
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -75,7 +71,7 @@ class EndToEndTests(BaseTestCase):
     def test_issue_638(self):
         """When a process outputs something on its stdout or stderr file
         descriptor that is not valid UTF-8, supervisord should not crash."""
-        filename = str(resource_files(__package__).joinpath('fixtures/issue-638.conf'))
+        filename = resources.find(__package__, 'fixtures/issue-638.conf')
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -94,7 +90,7 @@ class EndToEndTests(BaseTestCase):
     def test_issue_663(self):
         """When Supervisor is run on Python 3, the eventlistener protocol
         should work."""
-        filename = str(resource_files(__package__).joinpath('fixtures/issue-663.conf'))
+        filename = resources.find(__package__, 'fixtures/issue-663.conf')
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -106,7 +102,7 @@ class EndToEndTests(BaseTestCase):
         """When a subprocess name has Unicode characters, 'supervisord'
         should not send incomplete XML-RPC responses and 'supervisorctl
         status' should work."""
-        filename = str(resource_files(__package__).joinpath('fixtures/issue-664.conf'))
+        filename = resources.find(__package__, 'fixtures/issue-664.conf')
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -125,7 +121,7 @@ class EndToEndTests(BaseTestCase):
     def test_issue_733(self):
         """When a subprocess enters the FATAL state, a one-line eventlistener
         can be used to signal supervisord to shut down."""
-        filename = str(resource_files(__package__).joinpath('fixtures/issue-733.conf'))
+        filename = resources.find(__package__, 'fixtures/issue-733.conf')
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -134,7 +130,7 @@ class EndToEndTests(BaseTestCase):
         supervisord.expect(pexpect.EOF)
 
     def test_issue_835(self):
-        filename = str(resource_files(__package__).joinpath('fixtures/issue-835.conf'))
+        filename = resources.find(__package__, 'fixtures/issue-835.conf')
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -150,7 +146,7 @@ class EndToEndTests(BaseTestCase):
             transport.connection.close()
 
     def test_issue_836(self):
-        filename = str(resource_files(__package__).joinpath('fixtures/issue-836.conf'))
+        filename = resources.find(__package__, 'fixtures/issue-836.conf')
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -173,7 +169,7 @@ class EndToEndTests(BaseTestCase):
     def test_issue_986_command_string_with_double_percent(self):
         """A percent sign can be used in a command= string without being
         expanded if it is escaped by a second percent sign."""
-        filename = str(resource_files(__package__).joinpath('fixtures/issue-986.conf'))
+        filename = resources.find(__package__, 'fixtures/issue-986.conf')
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -182,7 +178,7 @@ class EndToEndTests(BaseTestCase):
     def test_issue_1054(self):
         """When run on Python 3, the 'supervisorctl avail' command
         should work."""
-        filename = str(resource_files(__package__).joinpath('fixtures/issue-1054.conf'))
+        filename = resources.find(__package__, 'fixtures/issue-1054.conf')
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -200,7 +196,7 @@ class EndToEndTests(BaseTestCase):
         """When the [supervisord] section has a variable defined in
         environment=, that variable should be able to be used in an
         %(ENV_x) expansion in a [program] section."""
-        filename = str(resource_files(__package__).joinpath('fixtures/issue-1170a.conf'))
+        filename = resources.find(__package__, 'fixtures/issue-1170a.conf')
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -211,7 +207,7 @@ class EndToEndTests(BaseTestCase):
         environment=, and a variable by the same name is defined in
         enviroment= of a [program] section, the one in the [program]
         section should be used."""
-        filename = str(resource_files(__package__).joinpath('fixtures/issue-1170b.conf'))
+        filename = resources.find(__package__, 'fixtures/issue-1170b.conf')
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -222,7 +218,7 @@ class EndToEndTests(BaseTestCase):
         environment=, and a variable by the same name is defined in
         enviroment= of an [eventlistener] section, the one in the
         [eventlistener] section should be used."""
-        filename = str(resource_files(__package__).joinpath('fixtures/issue-1170c.conf'))
+        filename = resources.find(__package__, 'fixtures/issue-1170c.conf')
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -233,7 +229,7 @@ class EndToEndTests(BaseTestCase):
         then the non-rotating logger will be used to avoid an
         IllegalSeekError in the case that the user has configured a
         non-seekable file like /dev/stdout."""
-        filename = str(resource_files(__package__).joinpath('fixtures/issue-1224.conf'))
+        filename = resources.find(__package__, 'fixtures/issue-1224.conf')
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -242,7 +238,7 @@ class EndToEndTests(BaseTestCase):
     def test_issue_1231a(self):
         """When 'supervisorctl tail -f name' is run and the log contains
         unicode, it should not fail."""
-        filename = str(resource_files(__package__).joinpath('fixtures/issue-1231a.conf'))
+        filename = resources.find(__package__, 'fixtures/issue-1231a.conf')
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -259,7 +255,7 @@ class EndToEndTests(BaseTestCase):
     def test_issue_1231b(self):
         """When 'supervisorctl tail -f name' is run and the log contains
         unicode, it should not fail."""
-        filename = str(resource_files(__package__).joinpath('fixtures/issue-1231b.conf'))
+        filename = resources.find(__package__, 'fixtures/issue-1231b.conf')
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -293,7 +289,7 @@ class EndToEndTests(BaseTestCase):
     def test_issue_1231c(self):
         """When 'supervisorctl tail -f name' is run and the log contains
         unicode, it should not fail."""
-        filename = str(resource_files(__package__).joinpath('fixtures/issue-1231c.conf'))
+        filename = resources.find(__package__, 'fixtures/issue-1231c.conf')
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -335,7 +331,7 @@ class EndToEndTests(BaseTestCase):
         """When the output of 'supervisorctl tail -f worker' is piped such as
         'supervisor tail -f worker | grep something', 'supervisorctl' should
         not crash."""
-        filename = str(resource_files(__package__).joinpath('fixtures/issue-1298.conf'))
+        filename = resources.find(__package__, 'fixtures/issue-1298.conf')
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -369,7 +365,7 @@ class EndToEndTests(BaseTestCase):
     def test_issue_1483a_identifier_default(self):
         """When no identifier is supplied on the command line or in the config
         file, the default is used."""
-        filename = str(resource_files(__package__).joinpath('fixtures/issue-1483a.conf'))
+        filename = resources.find(__package__, 'fixtures/issue-1483a.conf')
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -388,7 +384,7 @@ class EndToEndTests(BaseTestCase):
     def test_issue_1483b_identifier_from_config_file(self):
         """When the identifier is supplied in the config file only, that
         identifier is used instead of the default."""
-        filename = str(resource_files(__package__).joinpath('fixtures/issue-1483b.conf'))
+        filename = resources.find(__package__, 'fixtures/issue-1483b.conf')
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -407,7 +403,7 @@ class EndToEndTests(BaseTestCase):
     def test_issue_1483c_identifier_from_command_line(self):
         """When an identifier is supplied in both the config file and on the
         command line, the one from the command line is used."""
-        filename = str(resource_files(__package__).joinpath('fixtures/issue-1483c.conf'))
+        filename = resources.find(__package__, 'fixtures/issue-1483c.conf')
         args = ['-m', 'supervisor.supervisord', '-c', filename, '-i', 'from_command_line']
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)

--- a/supervisor/tests/test_end_to_end.py
+++ b/supervisor/tests/test_end_to_end.py
@@ -5,10 +5,13 @@ import os
 import signal
 import sys
 import unittest
-import pkg_resources
 from supervisor.compat import xmlrpclib
 from supervisor.xmlrpc import SupervisorTransport
 
+if sys.version_info >= (3, 9):
+    from importlib.resources import files as resource_files
+else:
+    from importlib_resources import files as resource_files
 
 # end-to-test tests are slow so only run them when asked
 if 'END_TO_END' in os.environ:
@@ -26,7 +29,7 @@ class EndToEndTests(BaseTestCase):
         passed to the child without the percent sign being mangled."""
         key = "SUPERVISOR_TEST_1441B"
         val = "foo_%s_%_%%_%%%_%2_bar"
-        filename = pkg_resources.resource_filename(__name__, 'fixtures/issue-291a.conf')
+        filename = str(resource_files(__package__).joinpath('fixtures/issue-291a.conf'))
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         try:
             os.environ[key] = val
@@ -39,7 +42,7 @@ class EndToEndTests(BaseTestCase):
     def test_issue_550(self):
         """When an environment variable is set in the [supervisord] section,
         it should be put into the environment of the subprocess."""
-        filename = pkg_resources.resource_filename(__name__, 'fixtures/issue-550.conf')
+        filename = str(resource_files(__package__).joinpath('fixtures/issue-550.conf'))
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -55,7 +58,7 @@ class EndToEndTests(BaseTestCase):
     def test_issue_565(self):
         """When a log file has Unicode characters in it, 'supervisorctl
         tail -f name' should still work."""
-        filename = pkg_resources.resource_filename(__name__, 'fixtures/issue-565.conf')
+        filename = str(resource_files(__package__).joinpath('fixtures/issue-565.conf'))
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -72,7 +75,7 @@ class EndToEndTests(BaseTestCase):
     def test_issue_638(self):
         """When a process outputs something on its stdout or stderr file
         descriptor that is not valid UTF-8, supervisord should not crash."""
-        filename = pkg_resources.resource_filename(__name__, 'fixtures/issue-638.conf')
+        filename = str(resource_files(__package__).joinpath('fixtures/issue-638.conf'))
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -91,7 +94,7 @@ class EndToEndTests(BaseTestCase):
     def test_issue_663(self):
         """When Supervisor is run on Python 3, the eventlistener protocol
         should work."""
-        filename = pkg_resources.resource_filename(__name__, 'fixtures/issue-663.conf')
+        filename = str(resource_files(__package__).joinpath('fixtures/issue-663.conf'))
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -103,7 +106,7 @@ class EndToEndTests(BaseTestCase):
         """When a subprocess name has Unicode characters, 'supervisord'
         should not send incomplete XML-RPC responses and 'supervisorctl
         status' should work."""
-        filename = pkg_resources.resource_filename(__name__, 'fixtures/issue-664.conf')
+        filename = str(resource_files(__package__).joinpath('fixtures/issue-664.conf'))
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -122,7 +125,7 @@ class EndToEndTests(BaseTestCase):
     def test_issue_733(self):
         """When a subprocess enters the FATAL state, a one-line eventlistener
         can be used to signal supervisord to shut down."""
-        filename = pkg_resources.resource_filename(__name__, 'fixtures/issue-733.conf')
+        filename = str(resource_files(__package__).joinpath('fixtures/issue-733.conf'))
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -131,7 +134,7 @@ class EndToEndTests(BaseTestCase):
         supervisord.expect(pexpect.EOF)
 
     def test_issue_835(self):
-        filename = pkg_resources.resource_filename(__name__, 'fixtures/issue-835.conf')
+        filename = str(resource_files(__package__).joinpath('fixtures/issue-835.conf'))
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -147,7 +150,7 @@ class EndToEndTests(BaseTestCase):
             transport.connection.close()
 
     def test_issue_836(self):
-        filename = pkg_resources.resource_filename(__name__, 'fixtures/issue-836.conf')
+        filename = str(resource_files(__package__).joinpath('fixtures/issue-836.conf'))
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -170,7 +173,7 @@ class EndToEndTests(BaseTestCase):
     def test_issue_986_command_string_with_double_percent(self):
         """A percent sign can be used in a command= string without being
         expanded if it is escaped by a second percent sign."""
-        filename = pkg_resources.resource_filename(__name__, 'fixtures/issue-986.conf')
+        filename = str(resource_files(__package__).joinpath('fixtures/issue-986.conf'))
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -179,7 +182,7 @@ class EndToEndTests(BaseTestCase):
     def test_issue_1054(self):
         """When run on Python 3, the 'supervisorctl avail' command
         should work."""
-        filename = pkg_resources.resource_filename(__name__, 'fixtures/issue-1054.conf')
+        filename = str(resource_files(__package__).joinpath('fixtures/issue-1054.conf'))
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -197,7 +200,7 @@ class EndToEndTests(BaseTestCase):
         """When the [supervisord] section has a variable defined in
         environment=, that variable should be able to be used in an
         %(ENV_x) expansion in a [program] section."""
-        filename = pkg_resources.resource_filename(__name__, 'fixtures/issue-1170a.conf')
+        filename = str(resource_files(__package__).joinpath('fixtures/issue-1170a.conf'))
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -208,7 +211,7 @@ class EndToEndTests(BaseTestCase):
         environment=, and a variable by the same name is defined in
         enviroment= of a [program] section, the one in the [program]
         section should be used."""
-        filename = pkg_resources.resource_filename(__name__, 'fixtures/issue-1170b.conf')
+        filename = str(resource_files(__package__).joinpath('fixtures/issue-1170b.conf'))
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -219,7 +222,7 @@ class EndToEndTests(BaseTestCase):
         environment=, and a variable by the same name is defined in
         enviroment= of an [eventlistener] section, the one in the
         [eventlistener] section should be used."""
-        filename = pkg_resources.resource_filename(__name__, 'fixtures/issue-1170c.conf')
+        filename = str(resource_files(__package__).joinpath('fixtures/issue-1170c.conf'))
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -230,7 +233,7 @@ class EndToEndTests(BaseTestCase):
         then the non-rotating logger will be used to avoid an
         IllegalSeekError in the case that the user has configured a
         non-seekable file like /dev/stdout."""
-        filename = pkg_resources.resource_filename(__name__, 'fixtures/issue-1224.conf')
+        filename = str(resource_files(__package__).joinpath('fixtures/issue-1224.conf'))
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -239,7 +242,7 @@ class EndToEndTests(BaseTestCase):
     def test_issue_1231a(self):
         """When 'supervisorctl tail -f name' is run and the log contains
         unicode, it should not fail."""
-        filename = pkg_resources.resource_filename(__name__, 'fixtures/issue-1231a.conf')
+        filename = str(resource_files(__package__).joinpath('fixtures/issue-1231a.conf'))
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -256,7 +259,7 @@ class EndToEndTests(BaseTestCase):
     def test_issue_1231b(self):
         """When 'supervisorctl tail -f name' is run and the log contains
         unicode, it should not fail."""
-        filename = pkg_resources.resource_filename(__name__, 'fixtures/issue-1231b.conf')
+        filename = str(resource_files(__package__).joinpath('fixtures/issue-1231b.conf'))
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -290,7 +293,7 @@ class EndToEndTests(BaseTestCase):
     def test_issue_1231c(self):
         """When 'supervisorctl tail -f name' is run and the log contains
         unicode, it should not fail."""
-        filename = pkg_resources.resource_filename(__name__, 'fixtures/issue-1231c.conf')
+        filename = str(resource_files(__package__).joinpath('fixtures/issue-1231c.conf'))
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -332,7 +335,7 @@ class EndToEndTests(BaseTestCase):
         """When the output of 'supervisorctl tail -f worker' is piped such as
         'supervisor tail -f worker | grep something', 'supervisorctl' should
         not crash."""
-        filename = pkg_resources.resource_filename(__name__, 'fixtures/issue-1298.conf')
+        filename = str(resource_files(__package__).joinpath('fixtures/issue-1298.conf'))
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -366,7 +369,7 @@ class EndToEndTests(BaseTestCase):
     def test_issue_1483a_identifier_default(self):
         """When no identifier is supplied on the command line or in the config
         file, the default is used."""
-        filename = pkg_resources.resource_filename(__name__, 'fixtures/issue-1483a.conf')
+        filename = str(resource_files(__package__).joinpath('fixtures/issue-1483a.conf'))
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -385,7 +388,7 @@ class EndToEndTests(BaseTestCase):
     def test_issue_1483b_identifier_from_config_file(self):
         """When the identifier is supplied in the config file only, that
         identifier is used instead of the default."""
-        filename = pkg_resources.resource_filename(__name__, 'fixtures/issue-1483b.conf')
+        filename = str(resource_files(__package__).joinpath('fixtures/issue-1483b.conf'))
         args = ['-m', 'supervisor.supervisord', '-c', filename]
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)
@@ -404,7 +407,7 @@ class EndToEndTests(BaseTestCase):
     def test_issue_1483c_identifier_from_command_line(self):
         """When an identifier is supplied in both the config file and on the
         command line, the one from the command line is used."""
-        filename = pkg_resources.resource_filename(__name__, 'fixtures/issue-1483c.conf')
+        filename = str(resource_files(__package__).joinpath('fixtures/issue-1483c.conf'))
         args = ['-m', 'supervisor.supervisord', '-c', filename, '-i', 'from_command_line']
         supervisord = pexpect.spawn(sys.executable, args, encoding='utf-8')
         self.addCleanup(supervisord.kill, signal.SIGINT)


### PR DESCRIPTION
This reduces the installation footprint and potential memory implications from merely importing it

On Python 3.8+ no dependencies are required