### PR TITLE
Remove python3.3 case

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,6 @@ requires = [
     "importlib-resources; python_version < '3.7'",
 ]
 tests_require = []
-if py_version < (3, 3):
-    tests_require.append('mock<4.0.0.dev0')
 
 testing_extras = tests_require + [
     'pytest',


### PR DESCRIPTION
Miminal current python3 requirement is 3.4 so this case can't occur.