### PR TITLE
rdflib.net is now rdflib.dev

### DIFF
--- a/supervisor/http_client.py
+++ b/supervisor/http_client.py
@@ -1,4 +1,4 @@
-# this code based on Daniel Krech's RDFLib HTTP client code (see rdflib.net)
+# this code based on Daniel Krech's RDFLib HTTP client code (see rdflib.dev)
 
 import sys
 import socket


### PR DESCRIPTION
rdflib.net is now owned by a domain squatter that relays to a gambling site.