### PR TITLE
Add maxbackoff and backoffincrement options

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -919,6 +919,8 @@ class ServerOptions(Options):
         autorestart = auto_restart(get(section, 'autorestart', 'unexpected'))
         startsecs = integer(get(section, 'startsecs', 1))
         startretries = integer(get(section, 'startretries', 3))
+        maxbackoff = integer(get(section, 'maxbackoff', 0))
+        backoffincrement = integer(get(section, 'backoffincrement', 1))
         stopsignal = signal_number(get(section, 'stopsignal', 'TERM'))
         stopwaitsecs = integer(get(section, 'stopwaitsecs', 10))
         stopasgroup = boolean(get(section, 'stopasgroup', 'false'))
@@ -1870,6 +1872,7 @@ class ProcessConfig(Config):
     req_param_names = [
         'name', 'uid', 'command', 'directory', 'umask', 'priority',
         'autostart', 'autorestart', 'startsecs', 'startretries',
+        'maxbackoff', 'backoffincrement,'
         'stdout_logfile', 'stdout_capture_maxbytes',
         'stdout_events_enabled', 'stdout_syslog',
         'stdout_logfile_backups', 'stdout_logfile_maxbytes',

--- a/supervisor/process.py
+++ b/supervisor/process.py
@@ -168,7 +168,8 @@ class Subprocess(object):
         self.state = new_state
         if new_state == ProcessStates.BACKOFF:
             now = time.time()
-            self.backoff += 1
+            if self.backoff < self.config.maxbackoff or self.config.maxbackoff == 0:
+                self.backoff += self.config.backoffincrement
             self.delay = now + self.backoff
 
         event_class = self.event_map.get(new_state)


### PR DESCRIPTION
* maxbackoff - the maximum number of seconds that supervisor will backoff before restart

* backoffincrement - the number of seconds to add to the backoff after each retry

based on https://github.com/Supervisor/supervisor/pull/1529