### PR TITLE
ESRF's  addition for group IDs from sssd

### DIFF
--- a/grouplist.py
+++ b/grouplist.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python
+import pwd, os
+from ctypes import *
+from ctypes.util import find_library
+
+libc = cdll.LoadLibrary(find_library('libc'))
+getgrouplist = libc.getgrouplist
+
+def grouplist(username, startmax=50):
+    # 50 groups should be enought?
+    ngroups = startmax
+    getgrouplist.argtypes = [c_char_p, c_uint, POINTER(c_uint * ngroups), POINTER(c_int)]
+    getgrouplist.restype = c_int32
+
+    gidlist = (c_uint * ngroups)()
+    ngrouplist = c_int(ngroups)
+
+    user = pwd.getpwnam(username)
+
+    ct = getgrouplist(user.pw_name, user.pw_gid, byref(gidlist), byref(ngrouplist))
+
+    # If 50 groups was not enought this will be -1, try again
+    # luckily the last call put the correct number of groups in ngrouplist
+    if ct < 0:
+        getgrouplist.argtypes = [c_char_p, c_uint, POINTER(c_uint *int(ngrouplist.value)), POINTER(c_int)]
+        gidlist = (c_uint * int(ngrouplist.value))()
+        ct = getgrouplist(user.pw_name, user.pw_gid, byref(gidlist), byref(ngrouplist))
+
+    for i in xrange(0, ct):
+        gid = gidlist[i]
+        yield int(gid)

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -55,6 +55,9 @@ from supervisor import states
 from supervisor import xmlrpc
 from supervisor import poller
 
+# ESRF's  addition for group IDs from sssd
+from supervisor.grouplist import grouplist
+
 def _read_version_txt():
     mydir = os.path.abspath(os.path.dirname(__file__))
     version_txt = os.path.join(mydir, 'version.txt')
@@ -1387,8 +1390,10 @@ class ServerOptions(Options):
         gid = pwrec[3]
         if hasattr(os, 'setgroups'):
             user = pwrec[0]
-            groups = [grprec[2] for grprec in grp.getgrall() if user in
-                      grprec[3]]
+            # groups = [grprec[2] for grprec in grp.getgrall() if user in
+                      # grprec[3]]
+            # ESRF's  addition for group IDs from sssd
+            groups = list(grouplist(user))
 
             # always put our primary gid first in this list, otherwise we can
             # lose group info since sometimes the first group in the setgroups


### PR DESCRIPTION
Gives child processes the effective Group IDs, even, when they are their definition is made in a sssd.
Solves https://github.com/Supervisor/supervisor/issues/1030