### PR TITLE
Add missing channel field to process log event docs

### DIFF
--- a/docs/events.rst
+++ b/docs/events.rst
@@ -660,7 +660,7 @@ Body Description
 
 .. code-block:: text
 
-   processname:name groupname:name pid:pid
+   processname:name groupname:name pid:pid channel:stdout
    data
 
 ``PROCESS_LOG_STDERR`` Event Type
@@ -680,7 +680,7 @@ Body Description
 
 .. code-block:: text
 
-   processname:name groupname:name pid:pid
+   processname:name groupname:name pid:pid channel:stderr
    data
 
 ``PROCESS_COMMUNICATION`` Event Type


### PR DESCRIPTION
Process log events (from both stdout and stderr) have channel
information in their payload. The docs have been updated to reflect
this.
