### PR TITLE
Fix tests on Python 3.13

### DIFF
--- a/supervisor/tests/test_process.py
+++ b/supervisor/tests/test_process.py
@@ -39,7 +39,7 @@ class SubprocessTests(unittest.TestCase):
         from supervisor.states import ProcessStates
         from supervisor.process import getProcessStateDescription
         for statename, code in ProcessStates.__dict__.items():
-            if isinstance(code, int):
+            if not statename.startswith("__"):
                 self.assertEqual(getProcessStateDescription(code), statename)
 
     def test_ctor(self):


### PR DESCRIPTION
Python 3.13 added a [`__firstlineno__`](https://docs.python.org/3/reference/datamodel.html#type.__firstlineno__) attribute to classes whose value is an int, so the approach taken by
`SubprocessTests.test_getProcessStateDescription` to test only actual states no longer works.  Exclude all attributes starting with `__` instead.