### PR TITLE
tests: fix test_socket_manager.py with PyPy

### DIFF
--- a/supervisor/tests/test_socket_manager.py
+++ b/supervisor/tests/test_socket_manager.py
@@ -1,5 +1,6 @@
 """Test suite for supervisor.socket_manager"""
 
+import gc
 import os
 import unittest
 import socket
@@ -49,6 +50,7 @@ class ProxyTest(unittest.TestCase):
         proxy = self._makeOne(Subject(), on_delete=self.setOnDeleteCalled)
         self.assertEqual(5, proxy.getValue())
         proxy = None
+        gc_collect()
         self.assertTrue(self.on_deleteCalled)
 
 class ReferenceCounterTest(unittest.TestCase):
@@ -90,6 +92,9 @@ class ReferenceCounterTest(unittest.TestCase):
         self.assertRaises(Exception, ctr.decrement)
 
 class SocketManagerTest(unittest.TestCase):
+
+    def tearDown(self):
+        gc_collect()
 
     def _getTargetClass(self):
         from supervisor.socket_manager import SocketManager
@@ -154,10 +159,12 @@ class SocketManagerTest(unittest.TestCase):
         self.assertTrue(sock_manager.is_prepared())
         self.assertFalse(sock_manager.socket.close_called)
         sock = None
+        gc_collect()
         # Socket not actually closed yet b/c ref ct is 1
         self.assertTrue(sock_manager.is_prepared())
         self.assertFalse(sock_manager.socket.close_called)
         sock2 = None
+        gc_collect()
         # Socket closed
         self.assertFalse(sock_manager.is_prepared())
         self.assertTrue(sock_manager.socket.close_called)
@@ -170,6 +177,7 @@ class SocketManagerTest(unittest.TestCase):
         self.assertNotEqual(sock_id, sock3_id)
         # Drop ref ct to zero
         del sock3
+        gc_collect()
         # Now assert that socket is closed
         self.assertFalse(sock_manager.is_prepared())
         self.assertTrue(sock_manager.socket.close_called)
@@ -184,6 +192,7 @@ class SocketManagerTest(unittest.TestCase):
         self.assertEqual('Creating socket %s' % repr(conf), logger.data[0])
         # socket close
         del sock
+        gc_collect()
         self.assertEqual(len(logger.data), 2)
         self.assertEqual('Closing socket %s' % repr(conf), logger.data[1])
 
@@ -232,3 +241,9 @@ class SocketManagerTest(unittest.TestCase):
             self.fail()
         except Exception as e:
             self.assertEqual(e.args[0], 'Socket has not been prepared')
+
+def gc_collect():
+    if __pypy__ is not None:
+        gc.collect()
+        gc.collect()
+        gc.collect()


### PR DESCRIPTION
Hi,
This is basically reapplying 0ad4db8e1411 which was removed in 49b74cafb6e7.
Without this patch, we got:
```
platform linux -- Python 3.10.14[pypy-7.3.17-final], pytest-8.3.4, pluggy-1.5.0
[…]
FAILED supervisor/tests/test_socket_manager.py::ProxyTest::test_on_delete - AssertionError: False is not true
FAILED supervisor/tests/test_socket_manager.py::SocketManagerTest::test_logging - AssertionError: 1 != 2
FAILED supervisor/tests/test_socket_manager.py::SocketManagerTest::test_socket_lifecycle - AssertionError: True is not false
FAILED supervisor/tests/test_socket_manager.py::SocketManagerTest::test_tcp_w_hostname - OSError: [Errno 98] Address already in use
FAILED supervisor/tests/test_socket_manager.py::SocketManagerTest::test_tcp_w_ip - OSError: [Errno 98] Address already in use
```

First discovered at https://github.com/gentoo/gentoo/pull/40173#issuecomment-2603322872