### PR TITLE
fix: [supervisord] environment section does not properly escape %%

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -657,7 +657,7 @@ class ServerOptions(Options):
         section.nocleanup = boolean(get('nocleanup', 'false'))
         section.strip_ansi = boolean(get('strip_ansi', 'false'))
 
-        environ_str = get('environment', '')
+        environ_str = get('environment', '', do_expand=False)
         environ_str = expand(environ_str, expansions, 'environment')
         section.environment = dict_of_key_value_pairs(environ_str)
 

--- a/supervisor/tests/test_options.py
+++ b/supervisor/tests/test_options.py
@@ -3409,6 +3409,18 @@ class ServerOptionsTests(unittest.TestCase, IncludeTestsMixin):
         instance.poller.before_daemonize.assert_called_once_with()
         instance.poller.after_daemonize.assert_called_once_with()
 
+    def test_options_environment_of_supervisord_with_escaped_chars(self):
+        text = lstrip("""
+        [supervisord]
+        environment=VAR_WITH_P="some_value_%%_end"
+        """)
+
+        instance = self._makeOne()
+        instance.configfile = StringIO(text)
+        instance.realize(args=[])
+        options = instance.configroot.supervisord
+        self.assertEqual(options.environment, dict(VAR_WITH_P="some_value_%_end"))
+
 class ProcessConfigTests(unittest.TestCase):
     def _getTargetClass(self):
         from supervisor.options import ProcessConfig


### PR DESCRIPTION
Hi,
I encountered an issue with '%%' escaping failure when configuring environment variables in the supervisor configuration file.
My configuration file is as follows:
```
[unix_http_server]
file = /cnb/devsandbox/supervisor/supervisor.sock

[supervisorctl]
serverurl = unix:///cnb/devsandbox/supervisor/supervisor.sock

[supervisord]
pidfile     = /cnb/devsandbox/supervisor/supervisord.pid
logfile     = /cnb/devsandbox/supervisor/log/supervisord.log
interpolate = false
environment = 
SOURCE_FETCH_URL="http://ip:port/default/home/gotest2%%3Adefault%%3Amaster%%3Ac7c75432ebbdd32bd913fe8a05ae36eed9a5666c%%3Adev/tar?AWSAccessKeyId=example&Signature=example%%2FMFI8%%3D&Expires=1756347407",
other environment variables...

[rpcinterface:supervisor]
supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface

[program:scheduler]
command         = /cnb/process/scheduler
stdout_logfile  = /cnb/devsandbox/supervisor/log/scheduler.log
redirect_stderr = true

[program:web]
command         = /cnb/process/web
stdout_logfile  = /cnb/devsandbox/supervisor/log/web.log
redirect_stderr = true

[inet_http_server]
port = 127.0.0.1:9001
```

When I started the supervisor server using the configuration file above, the following error occurred:
```
Error: Format string 'SOURCE_FETCH_URL="http://ip:port/default/home/gotest2%%3Adefault%%3Amaster%%3Ac7c75432ebbdd32bd913fe8a05ae36eed9a5666c%%3Adev/tar?AWSAccessKeyId=example&Signature=example%%2FMFI8%%3D&Expires=1756347407",
other environment variables...' for 'environment' is badly formatted: unsupported format character 'A' (0x41) at index 3460
```

However, when I moved the `environment` from the `[supervisord]` section to the `[program:***]` section, the aforementioned error did not occur.

Later, while reviewing the code related to environment variable processing, I found that in `supervisor/options.py:660`, the `%` was expanded prematurely, causing `%%` to be interpreted as `%`. This value was then passed to `expand()`, which attempted to expand it again, resulting in the error.

Therefore, `do_expand` should be set to `False` at `supervisor/options.py:660` to ensure proper escaping.