### PR TITLE
Fix compat.py: tail -f korean broken error exception

### DIFF
--- a/supervisor/compat.py
+++ b/supervisor/compat.py
@@ -51,13 +51,14 @@ else: # pragma: no cover
         if isinstance(s, bytes):
             return s
         else:
-            return s.encode(encoding)
+            return s.encode(encoding, errors='replace')
 
     def as_string(s, encoding='utf8'):
         if isinstance(s, str):
             return s
         else:
-            return s.decode(encoding)
+            # 인입된 bytes에서 깨진 부분은 '�'로 표시하고 나머지 부분은 계속 decode 진행
+            return s.decode(encoding, errors='replace')
 
     def is_text_stream(stream):
         import _io


### PR DESCRIPTION
###  Changes Made
 - Specific modifications made to compat.py
 - 54 line: return s.encode(encoding, errors='replace')
 - 60 line: return s.decode(encoding, errors='replace')

### Reason for Changes
 - tail -f garbled output when log has Korean characters

### Testing
supervisor> tail -f print_time
==> Press Ctrl-C to exit <==
��간: 2025. 09. 01.  00:27:25 KST
현재 시간: 2025. 09. 01.  00:27:25 KST
현재 시간: 2025. 09. 01.  00:27:25 KST
현재 시간: 2025. 09. 01.  00:27:26 KST


I realized there was an issue with the previous pull request.
I’m new to using GitHub and currently learning.
As a Korean user who frequently uses Supervisor, I hope you can consider reflecting the above changes, and I’m requesting this again.