### PR TITLE
Implement `sd_notify`

### DIFF
--- a/supervisor/tests/base.py
+++ b/supervisor/tests/base.py
@@ -31,6 +31,8 @@ class DummyOptions:
     make_pipes_exception = None
     remove_exception = None
     write_exception = None
+    notify_sock_path = None
+    notify_sock = None
 
     def __init__(self):
         self.identifier = 'supervisor'
@@ -116,6 +118,9 @@ class DummyOptions:
 
     def openhttpservers(self, supervisord):
         self.httpservers_opened = True
+
+    def open_notify_socket(self):
+        pass
 
     def daemonize(self):
         self.daemonized = True


### PR DESCRIPTION
Linux daemons (lldpd, rsyslogd, frr) use sd_notify mechanism to let systemd know when they are ready. This PR implements this for supervisord and transitions processes into READY state when READY=1 is received.