### PR TITLE
fix 1 sec delay on start

### DIFF
--- a/supervisor/supervisord.py
+++ b/supervisor/supervisord.py
@@ -173,11 +173,17 @@ class Supervisor:
 
     def runforever(self):
         events.notify(events.SupervisorRunningEvent())
-        timeout = 1 # this cannot be fewer than the smallest TickEvent (5)
+        first_poll = True
 
         socket_map = self.options.get_socket_map()
 
         while 1:
+            if first_poll:
+                timeout = 0
+                first_poll = False
+            else:
+                timeout = 1 # this cannot not be fewer than the smallest TickEvent (5)
+
             combined_map = {}
             combined_map.update(socket_map)
             combined_map.update(self.get_process_map())


### PR DESCRIPTION
We use supervisord in an environment that requires starting processes fast and even 1 sec counts.