### PR TITLE
Do not swallow error when importing plugins

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -374,9 +374,9 @@ class Options:
                                  (section, factory_key))
             try:
                 factory = self.import_spec(factory_spec)
-            except (AttributeError, ImportError):
-                raise ValueError('%s cannot be resolved within [%s]' % (
-                    factory_spec, section))
+            except (AttributeError, ImportError) as e:
+                raise ValueError('%s cannot be resolved within [%s]: %s' % (
+                    factory_spec, section, e))
 
             extras = {}
             for k in parser.options(section):
@@ -743,9 +743,9 @@ class ServerOptions(Options):
                                        'supervisor.dispatchers:default_handler')
             try:
                 result_handler = self.import_spec(result_handler)
-            except (AttributeError, ImportError):
-                raise ValueError('%s cannot be resolved within [%s]' % (
-                    result_handler, section))
+            except (AttributeError, ImportError) as e:
+                raise ValueError('%s cannot be resolved within [%s]: %s' % (
+                    result_handler, section, e))
 
             pool_event_names = [x.upper() for x in
                                 list_of_strings(get(section, 'events', ''))]

--- a/supervisor/tests/test_options.py
+++ b/supervisor/tests/test_options.py
@@ -2644,7 +2644,8 @@ class ServerOptionsTests(unittest.TestCase):
         except ValueError as exc:
             self.assertEqual(exc.args[0],
                 'thisishopefullynotanimportablepackage:nonexistent cannot be '
-                'resolved within [eventlistener:cat]')
+                'resolved within [eventlistener:cat]: No module named '
+                '\'thisishopefullynotanimportablepackage\'')
 
     def test_event_listener_pool_result_handler_unimportable_AttributeError(self):
         text = lstrip("""\
@@ -2663,7 +2664,8 @@ class ServerOptionsTests(unittest.TestCase):
         except ValueError as exc:
             self.assertEqual(exc.args[0],
                 'supervisor.tests.base:nonexistent cannot be '
-                'resolved within [eventlistener:cat]')
+                'resolved within [eventlistener:cat]: module '
+                '\'supervisor.tests.base\' has no attribute \'nonexistent\'')
 
     def test_event_listener_pool_noeventsline(self):
         text = lstrip("""\
@@ -3216,7 +3218,7 @@ class ServerOptionsTests(unittest.TestCase):
             self.fail('nothing raised')
         except ValueError as exc:
             self.assertEqual(exc.args[0], 'nonexistent cannot be resolved '
-                'within [rpcinterface:dummy]')
+                'within [rpcinterface:dummy]: No module named \'nonexistent\'')
 
     def test_clear_autochildlogdir(self):
         dn = tempfile.mkdtemp()


### PR DESCRIPTION
I had an error in knot-resolver v6 when importing its plugin which before looked like:

```
Error: knot_resolver.controller.supervisord.plugin.patch_logger:inject cannot be resolved within [rpcinterface:patch_logger]
```

which was not very actionable or clear for me.

Now the error is:

```
Error: knot_resolver.controller.supervisord.plugin.patch_logger:inject cannot be resolved within [rpcinterface:patch_logger]: No module named 'knot_resolver'
```