### PR TITLE
Indefinite, fast restarts when 'startretries' = -1

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -752,7 +752,8 @@ where specified.
 
   The number of serial failure attempts that :program:`supervisord`
   will allow when attempting to start the program before giving up and
-  putting the process into an ``FATAL`` state.
+  putting the process into an ``FATAL`` state. If set to ``-1`` it will
+  retry forever without increasing the delay between retries.
 
   .. note::
 

--- a/docs/subprocess.rst
+++ b/docs/subprocess.rst
@@ -255,7 +255,8 @@ automatically restarted by :program:`supervisord`.  It will switch
 between ``STARTING`` and ``BACKOFF`` states until it becomes evident
 that it cannot be started because the number of ``startretries`` has
 exceeded the maximum, at which point it will transition to the
-``FATAL`` state.
+``FATAL`` state. If ``startretries`` is set to ``-1``, it will retry
+indefinitely without reaching the ``FATAL`` state.
 
 .. note::
     Retries will take increasingly more time depending on the number of

--- a/supervisor/process.py
+++ b/supervisor/process.py
@@ -677,8 +677,8 @@ class Subprocess(object):
                     # STOPPED -> STARTING
                     self.spawn()
             elif state == ProcessStates.BACKOFF:
-                if self.backoff <= self.config.startretries:
-                    if now > self.delay:
+                if self.backoff <= self.config.startretries or self.config.startretries == -1:
+                    if now > self.delay or self.config.startretries == -1:
                         # BACKOFF -> STARTING
                         self.spawn()
 
@@ -698,7 +698,7 @@ class Subprocess(object):
                 logger.info('success: %s %s' % (processname, msg))
 
         if state == ProcessStates.BACKOFF:
-            if self.backoff > self.config.startretries:
+            if self.backoff > self.config.startretries and self.config.startretries != -1:
                 # BACKOFF -> FATAL if the proc has exceeded its number
                 # of retries
                 self.give_up()


### PR DESCRIPTION
Hi, first many thanks for developing supervisor!

This pull request updates the behavior and documentation of the startretries configuration option to support infinite retries when set to -1. Also it is skipping the otherwise always increasing delays.

When developing in an environment with hot-reload, I found myself sometimes being restricted by long restart times. This change solved this for me. I'd be very happy if that change would make it in the official repo, but I can also understand if this shouldn't be a part of supervisor.

Best regards,
Tell