### PR TITLE
supervisord: skip idle reaping without child pids

### DIFF
--- a/supervisor/supervisord.py
+++ b/supervisor/supervisord.py
@@ -45,6 +45,8 @@ from supervisor import events
 from supervisor.states import SupervisorStates
 from supervisor.states import getProcessStateDescription
 
+_NO_SIGNAL = object()
+
 class Supervisor:
     stopping = False # set after we detect that we are handling a stop request
     lastshutdownreport = 0 # throttle for delayed process error reports at stop
@@ -261,8 +263,10 @@ class Supervisor:
             for group in pgroups:
                 group.transition()
 
-            self.reap()
-            self.handle_signal()
+            sig = self.options.get_signal()
+            if self.options.pidhistory:
+                self.reap()
+            self.handle_signal(sig)
             self.tick()
 
             if self.options.mood < SupervisorStates.RUNNING:
@@ -305,8 +309,9 @@ class Supervisor:
                 # infinitely
                 self.reap(once=False, recursionguard=recursionguard+1)
 
-    def handle_signal(self):
-        sig = self.options.get_signal()
+    def handle_signal(self, sig=_NO_SIGNAL):
+        if sig is _NO_SIGNAL:
+            sig = self.options.get_signal()
         if sig:
             if sig in (signal.SIGTERM, signal.SIGINT, signal.SIGQUIT):
                 self.options.logger.warn(

--- a/supervisor/tests/base.py
+++ b/supervisor/tests/base.py
@@ -60,6 +60,7 @@ class DummyOptions:
         self.pidfile_written = False
         self.directory = None
         self.waitpid_return = None, None
+        self.waitpid_calls = 0
         self.kills = {}
         self._signal = None
         self.parent_pipes_closed = None
@@ -145,6 +146,7 @@ class DummyOptions:
         self.pidfile_written = True
 
     def waitpid(self):
+        self.waitpid_calls += 1
         return self.waitpid_return
 
     def kill(self, pid, sig):

--- a/supervisor/tests/test_supervisord.py
+++ b/supervisor/tests/test_supervisord.py
@@ -665,6 +665,60 @@ class SupervisordTests(unittest.TestCase):
         supervisord.runforever()
         self.assertEqual(len(supervisord.ticks), 3)
 
+    def test_runforever_skips_reap_without_child_pids(self):
+        options = DummyOptions()
+        options.test = True
+        supervisord = self._makeOne(options)
+        supervisord.runforever()
+        self.assertEqual(options.waitpid_calls, 0)
+
+    def test_runforever_reads_signal_once_without_child_pids(self):
+        import signal
+        options = DummyOptions()
+        options.test = True
+        signals = [None, signal.SIGCHLD]
+
+        def get_signal():
+            return signals.pop(0)
+
+        options.get_signal = get_signal
+        supervisord = self._makeOne(options)
+        supervisord.runforever()
+        self.assertEqual(signals, [signal.SIGCHLD])
+
+    def test_runforever_skips_reap_for_sigchld_without_child_pids(self):
+        import signal
+        options = DummyOptions()
+        options.test = True
+        options._signal = signal.SIGCHLD
+        supervisord = self._makeOne(options)
+        supervisord.runforever()
+        self.assertEqual(options.waitpid_calls, 0)
+        msgs = ('received SIGCHLD indicating a child quit',
+                'received SIGCLD indicating a child quit')
+        self.assertTrue(options.logger.data[0] in msgs)
+
+    def test_runforever_reaps_with_child_pids(self):
+        options = DummyOptions()
+        options.test = True
+        pconfig = DummyPConfig(options, 'process', '/bin/foo', '/tmp')
+        process = DummyProcess(pconfig)
+        process.drained = False
+        process.killing = True
+        process.laststop = None
+        process.waitstatus = None, None
+        options.pidhistory[123] = process
+        waitpid_results = [(123, 0), (None, None)]
+
+        def waitpid():
+            options.waitpid_calls += 1
+            return waitpid_results.pop(0)
+
+        options.waitpid = waitpid
+        supervisord = self._makeOne(options)
+        supervisord.runforever()
+        self.assertEqual(options.waitpid_calls, 2)
+
     def test_runforever_poll_dispatchers(self):
         options = DummyOptions()
         options.poller.result = [6], [7, 8]


### PR DESCRIPTION
## Summary

`Supervisor.runforever()` currently calls `reap()` on every loop iteration after polling and process state transitions. When there are no tracked child PIDs, this still asks `waitpid()` for child status on every idle tick.

This change skips the periodic reap unless Supervisor has tracked child PIDs. The main loop reads the pending signal once and passes it to `handle_signal()`, so `SIGCHLD` is still logged through the existing signal path without an extra idle `waitpid()` call.

## Validation

- `python3 -m pytest supervisor/tests/test_supervisord.py -q`
- `END_TO_END=1 python3 -m pytest supervisor/tests/test_end_to_end.py::EndToEndTests::test_issue_1170a -q`
- `python3 -m pytest -q`
